### PR TITLE
EDM-1169: Incorrect configuration for Client/Agent TLS

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -89,7 +89,14 @@ func getTlsConfig(cfg *config.Config) *tls.Config {
 		InsecureSkipVerify: cfg.Auth.InsecureSkipTlsVerify, //nolint:gosec
 	}
 	if cfg.Auth.CACert != "" {
-		caCertPool := x509.NewCertPool()
+		// Start with system CAs to ensure compatibility with standard server certificates
+		caCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			// If system cert pool is not available, create a new one
+			caCertPool = x509.NewCertPool()
+		}
+		
+		// Add custom CAs to the existing pool
 		caCertPool.AppendCertsFromPEM([]byte(cfg.Auth.CACert))
 		tlsConfig.RootCAs = caCertPool
 	}

--- a/internal/crypto/tls.go
+++ b/internal/crypto/tls.go
@@ -46,10 +46,18 @@ func TLSConfigForServer(caBundlex509 []*x509.Certificate, serverConfig *TLSCerti
 }
 
 func TLSConfigForClient(caBundleX509 []*x509.Certificate, clientConfig *TLSCertificateConfig) (*tls.Config, error) {
-	caPool := x509.NewCertPool()
+	// Start with system CAs to ensure compatibility with standard server certificates
+	caPool, err := x509.SystemCertPool()
+	if err != nil {
+		// If system cert pool is not available, create a new one
+		caPool = x509.NewCertPool()
+	}
+	
+	// Add custom CAs to the pool
 	for _, caCert := range caBundleX509 {
 		caPool.AddCert(caCert)
 	}
+	
 	tlsConfig := &tls.Config{
 		RootCAs:    caPool,
 		MinVersion: tls.VersionTLS13,


### PR DESCRIPTION
This PR addresses the issue described in EDM-1169.

**Summary:** Incorrect configuration for Client/Agent TLS

**Description:** *Description of the problem:*

All client config in flightctl assumes that the server certificate is issued by the same authority which is used for issuing client certificates and mTLS authentication.

*How reproducible:*

Always

*Steps to reproduce:*

 
 # Try to load a cert issued by a different authority

*Actual results:*

mTLS Fail

*Expected results:*

mTLS Success