### PR TITLE
EDM-1169: Incorrect configuration for Client/Agent TLS

### DIFF
--- a/internal/crypto/tls.go
+++ b/internal/crypto/tls.go
@@ -46,10 +46,20 @@ func TLSConfigForServer(caBundlex509 []*x509.Certificate, serverConfig *TLSCerti
 }
 
 func TLSConfigForClient(caBundleX509 []*x509.Certificate, clientConfig *TLSCertificateConfig) (*tls.Config, error) {
-	caPool := x509.NewCertPool()
+	// Start with system certificate pool to include system CAs
+	caPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+	if caPool == nil {
+		caPool = x509.NewCertPool()
+	}
+	
+	// Add the provided CA bundle to the pool
 	for _, caCert := range caBundleX509 {
 		caPool.AddCert(caCert)
 	}
+	
 	tlsConfig := &tls.Config{
 		RootCAs:    caPool,
 		MinVersion: tls.VersionTLS13,


### PR DESCRIPTION
This PR addresses the issue described in [EDM-1169](https://issues.redhat.com/browse/EDM-1169).

**Summary:** Incorrect configuration for Client/Agent TLS

**Description:** *Description of the problem:*

All client config in flightctl assumes that the server certificate is issued by the same authority which is used for issuing client certificates and mTLS authentication.

*How reproducible:*

Always

*Steps to reproduce:*

 
 # Try to load a cert issued by a different authority

*Actual results:*

mTLS Fail

*Expected results:*

mTLS Success

**Assignee:** Asaf Ben Natan (abennata@redhat.com)