### PR TITLE
EDM-3899-service-config-restoration

### DIFF
--- a/internal/restore/deployer.go
+++ b/internal/restore/deployer.go
@@ -2,7 +2,10 @@ package restore
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -105,12 +108,12 @@ type deploymentInfo struct {
 //   - External namespace (Internal=false): api, imagebuilder-api, alertmanager-proxy
 //   - Internal namespace (Internal=true):  worker, periodic, imagebuilder-worker, alert-exporter
 var defaultDeploymentRegistry = []deploymentInfo{
-	{Name: "flightctl-api",                Internal: false},
-	{Name: "flightctl-worker",             Internal: true},
-	{Name: "flightctl-periodic",           Internal: true},
-	{Name: "flightctl-imagebuilder-api",   Internal: false},
+	{Name: "flightctl-api", Internal: false},
+	{Name: "flightctl-worker", Internal: true},
+	{Name: "flightctl-periodic", Internal: true},
+	{Name: "flightctl-imagebuilder-api", Internal: false},
 	{Name: "flightctl-imagebuilder-worker", Internal: true},
-	{Name: "flightctl-alert-exporter",     Internal: true},
+	{Name: "flightctl-alert-exporter", Internal: true},
 	{Name: "flightctl-alertmanager-proxy", Internal: false},
 }
 
@@ -149,20 +152,29 @@ type Deployer interface {
 	// Returns an error if the pki/ subdirectory is absent from the archive.
 	// StopServices must be called before RestorePKI.
 	RestorePKI(ctx context.Context, extractDir string) error
+	// RestoreConfig restores service configuration from the extracted archive directory.
+	// For Podman: copies <extractDir>/config/service-config.yaml to the configured service
+	// config path and imports the PAM Issuer volume from <extractDir>/volumes/pam-issuer-etc.tar
+	// (optional — logs a warning if absent or if the import fails).
+	// For Kubernetes: decodes the backed-up Helm release Secret, applies it to the cluster,
+	// reconstructs the chart and user values from the release data, and runs helm upgrade.
+	// StopServices must be called before RestoreConfig.
+	RestoreConfig(ctx context.Context, extractDir string) error
 }
 
 // PodmanRestoreDeployer implements Deployer for Podman/quadlet deployments.
 type PodmanRestoreDeployer struct {
-	log               logrus.FieldLogger
-	containerName     string
-	containerCLI      string
-	serviceHandler    ServiceHandler
-	serviceConfigPath string
-	dbName            string
-	kvContainerName   string
-	pkiDestPath       string
-	keepOldDB         bool
-	cachedCfg         *config.Config
+	log                 logrus.FieldLogger
+	containerName       string
+	containerCLI        string
+	serviceHandler      ServiceHandler
+	serviceConfigPath   string
+	dbName              string
+	kvContainerName     string
+	pkiDestPath         string
+	pamIssuerVolumeName string
+	keepOldDB           bool
+	cachedCfg           *config.Config
 }
 
 // PodmanRestoreOption configures a PodmanRestoreDeployer.
@@ -235,6 +247,14 @@ func WithPodmanKeepOldDB(keep bool) PodmanRestoreOption {
 	}
 }
 
+// WithPAMIssuerVolumeName sets the Podman volume name for PAM Issuer volume restore.
+// Defaults to "flightctl-pam-issuer-etc".
+func WithPAMIssuerVolumeName(name string) PodmanRestoreOption {
+	return func(d *PodmanRestoreDeployer) {
+		d.pamIssuerVolumeName = name
+	}
+}
+
 // NewPodmanRestoreDeployer creates a PodmanRestoreDeployer.
 // Defaults: containerName "flightctl-db", containerCLI "podman",
 // kvContainerName "flightctl-kv",
@@ -267,6 +287,9 @@ func NewPodmanRestoreDeployer(
 	}
 	if d.pkiDestPath == "" {
 		d.pkiDestPath = "/etc/flightctl/pki"
+	}
+	if d.pamIssuerVolumeName == "" {
+		d.pamIssuerVolumeName = "flightctl-pam-issuer-etc"
 	}
 	return d
 }
@@ -544,6 +567,49 @@ func (p *PodmanRestoreDeployer) RestorePKI(ctx context.Context, extractDir strin
 	return nil
 }
 
+// RestoreConfig copies service-config.yaml from the archive to the configured service
+// config path and imports the PAM Issuer volume (optional). Returns an error only if
+// service-config.yaml is absent from the archive; PAM Issuer volume failures are logged
+// as warnings since the component is optional.
+func (p *PodmanRestoreDeployer) RestoreConfig(ctx context.Context, extractDir string) error {
+	srcConfig := filepath.Join(extractDir, "config", "service-config.yaml")
+	info, err := os.Stat(srcConfig)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("service configuration not found in archive: %s", srcConfig)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to access service configuration in archive: %w", err)
+	}
+
+	data, err := os.ReadFile(srcConfig)
+	if err != nil {
+		return fmt.Errorf("failed to read service configuration from archive: %w", err)
+	}
+	if err := os.WriteFile(p.serviceConfigPath, data, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("failed to write service configuration to %s: %w", p.serviceConfigPath, err)
+	}
+	p.log.Infof("Service configuration restored: %s", p.serviceConfigPath)
+	p.cachedCfg = nil
+
+	volumeArchive := filepath.Join(extractDir, "volumes", "pam-issuer-etc.tar")
+	if _, err := os.Stat(volumeArchive); os.IsNotExist(err) {
+		p.log.Warn("PAM Issuer volume archive not found in backup — skipping PAM Issuer volume restore")
+		return nil
+	} else if err != nil {
+		p.log.Warnf("Failed to access PAM Issuer volume archive: %v — skipping", err)
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, p.containerCLI, "volume", "import", p.pamIssuerVolumeName, volumeArchive)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		p.log.Warnf("Failed to import PAM Issuer volume %q: %v (output: %s) — service may need manual configuration",
+			p.pamIssuerVolumeName, err, out)
+		return nil
+	}
+	p.log.Infof("PAM Issuer volume restored: %s", p.pamIssuerVolumeName)
+	return nil
+}
+
 // KubernetesRestoreDeployer implements Deployer for Kubernetes/Helm deployments.
 type KubernetesRestoreDeployer struct {
 	log               logrus.FieldLogger
@@ -552,9 +618,44 @@ type KubernetesRestoreDeployer struct {
 	clientset         kubernetes.Interface
 	restCfg           *rest.Config
 	keepOldDB         bool
+	helmUpgradeFunc   func(ctx context.Context, releaseName, chartDir, namespace, valuesFile string) error
 	// originalReplicas holds pre-stop replica counts so StartServices can restore them.
 	originalReplicas map[string]int32
 	cachedCfg        *config.Config
+}
+
+// defaultHelmUpgrade runs helm upgrade using the system helm CLI.
+func defaultHelmUpgrade(ctx context.Context, releaseName, chartDir, namespace, valuesFile string) error {
+	cmd := exec.CommandContext(ctx, "helm", "upgrade", releaseName, chartDir,
+		"--namespace", namespace, "--values", valuesFile)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("helm upgrade failed: %w (output: %s)", err, out)
+	}
+	return nil
+}
+
+// helmReleaseJSON is a minimal representation of the Helm 3 release JSON used
+// to extract chart and user-values for helm upgrade during restore.
+type helmReleaseJSON struct {
+	Name      string                 `json:"name"`
+	Chart     *helmChartJSON         `json:"chart"`
+	Config    map[string]interface{} `json:"config"`
+	Namespace string                 `json:"namespace"`
+}
+
+type helmChartJSON struct {
+	Metadata  map[string]interface{} `json:"metadata"`
+	Templates []*helmFileJSON        `json:"templates"`
+	Values    map[string]interface{} `json:"values"`
+	Files     []*helmFileJSON        `json:"files"`
+}
+
+// helmFileJSON represents a file in a Helm chart. Data is a raw byte slice;
+// encoding/json automatically decodes the base64 string from JSON into []byte.
+type helmFileJSON struct {
+	Name string `json:"name"`
+	Data []byte `json:"data"`
 }
 
 // KubernetesRestoreOption configures a KubernetesRestoreDeployer.
@@ -597,6 +698,14 @@ func WithKeepOldDB(keep bool) KubernetesRestoreOption {
 	}
 }
 
+// WithHelmUpgradeFunc injects a custom helm upgrade function (for testing).
+// The default runs the system helm CLI.
+func WithHelmUpgradeFunc(fn func(ctx context.Context, releaseName, chartDir, namespace, valuesFile string) error) KubernetesRestoreOption {
+	return func(d *KubernetesRestoreDeployer) {
+		d.helmUpgradeFunc = fn
+	}
+}
+
 // NewKubernetesRestoreDeployer creates a KubernetesRestoreDeployer.
 // Defaults: namespace "flightctl"; internalNamespace inherits namespace;
 // clientset nil → in-cluster client is created on first use;
@@ -617,6 +726,9 @@ func NewKubernetesRestoreDeployer(
 	}
 	if d.internalNamespace == "" {
 		d.internalNamespace = d.namespace
+	}
+	if d.helmUpgradeFunc == nil {
+		d.helmUpgradeFunc = defaultHelmUpgrade
 	}
 	return d
 }
@@ -954,8 +1066,8 @@ func (k *KubernetesRestoreDeployer) execRestoreDump(ctx context.Context, dbName,
 const (
 	// portForwardReadyTimeout is the maximum time to wait for a kubectl port-forward
 	// tunnel to become reachable before returning an error.
-	portForwardReadyTimeout  = 30 * time.Second
-	portForwardPollInterval  = 200 * time.Millisecond
+	portForwardReadyTimeout = 30 * time.Second
+	portForwardPollInterval = 200 * time.Millisecond
 )
 
 // ExposeService starts a kubectl port-forward to the named service and returns
@@ -1102,6 +1214,165 @@ func (k *KubernetesRestoreDeployer) applySecretFromFile(ctx context.Context, cli
 }
 
 // getFreePort asks the OS for a free local TCP port by binding to :0.
+// RestoreConfig applies the backed-up Helm release Secret to the cluster, then
+// reconstructs the chart and user values from the release data and runs helm upgrade.
+func (k *KubernetesRestoreDeployer) RestoreConfig(ctx context.Context, extractDir string) error {
+	configDir := filepath.Join(extractDir, "config")
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		return fmt.Errorf("failed to list config directory in archive: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		secretFile := filepath.Join(configDir, entry.Name())
+		if applyErr := k.applySecretFromFile(ctx, k.clientset, secretFile); applyErr != nil {
+			return fmt.Errorf("failed to apply config Secret %s: %w", entry.Name(), applyErr)
+		}
+		k.log.Infof("Applied Helm release Secret from %s", entry.Name())
+	}
+
+	return k.restoreHelmRelease(ctx, extractDir)
+}
+
+// restoreHelmRelease decodes the backed-up Helm release Secret, reconstructs the
+// chart directory and values file, and runs helm upgrade to bring the cluster state
+// in line with the backed-up configuration.
+func (k *KubernetesRestoreDeployer) restoreHelmRelease(ctx context.Context, extractDir string) error {
+	configDir := filepath.Join(extractDir, "config")
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		return fmt.Errorf("failed to list config directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		secretFile := filepath.Join(configDir, entry.Name())
+		data, err := os.ReadFile(secretFile)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", secretFile, err)
+		}
+
+		var secret corev1.Secret
+		if err := yaml.Unmarshal(data, &secret); err != nil {
+			k.log.Debugf("Skipping %s: not a valid Secret YAML: %v", entry.Name(), err)
+			continue
+		}
+		releaseBytes, ok := secret.Data["release"]
+		if !ok {
+			k.log.Debugf("Skipping %s: no 'release' key in Secret data", entry.Name())
+			continue
+		}
+
+		// Helm encodes release data as base64(gzip(json(release))).
+		gzipBytes, err := base64.StdEncoding.DecodeString(string(releaseBytes))
+		if err != nil {
+			return fmt.Errorf("failed to base64-decode Helm release from %s: %w", entry.Name(), err)
+		}
+		gr, err := gzip.NewReader(bytes.NewReader(gzipBytes))
+		if err != nil {
+			return fmt.Errorf("failed to gunzip Helm release from %s: %w", entry.Name(), err)
+		}
+		defer gr.Close()
+
+		var release helmReleaseJSON
+		if err := json.NewDecoder(gr).Decode(&release); err != nil {
+			return fmt.Errorf("failed to decode Helm release JSON from %s: %w", entry.Name(), err)
+		}
+
+		chartDir, err := os.MkdirTemp("", "flightctl-helm-chart-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp chart directory: %w", err)
+		}
+		defer os.RemoveAll(chartDir)
+
+		if err := k.writeHelmChart(chartDir, &release); err != nil {
+			return fmt.Errorf("failed to reconstruct Helm chart: %w", err)
+		}
+
+		valuesFile, err := os.CreateTemp("", "flightctl-helm-values-*.yaml")
+		if err != nil {
+			return fmt.Errorf("failed to create temp values file: %w", err)
+		}
+		valuesFile.Close()
+		defer os.Remove(valuesFile.Name())
+
+		userValues, err := yaml.Marshal(release.Config)
+		if err != nil {
+			return fmt.Errorf("failed to marshal user values: %w", err)
+		}
+		if err := os.WriteFile(valuesFile.Name(), userValues, 0600); err != nil {
+			return fmt.Errorf("failed to write user values file: %w", err)
+		}
+
+		ns := release.Namespace
+		if ns == "" {
+			ns = k.namespace
+		}
+		if err := k.helmUpgradeFunc(ctx, release.Name, chartDir, ns, valuesFile.Name()); err != nil {
+			return fmt.Errorf("helm upgrade for release %q failed: %w", release.Name, err)
+		}
+		k.log.Infof("Helm release %q upgraded successfully", release.Name)
+		return nil
+	}
+
+	k.log.Warn("No Helm release Secret found in archive config — skipping helm upgrade")
+	return nil
+}
+
+// writeHelmChart reconstructs a chart directory structure from decoded Helm release data.
+func (k *KubernetesRestoreDeployer) writeHelmChart(chartDir string, release *helmReleaseJSON) error {
+	if release.Chart == nil {
+		return fmt.Errorf("Helm release contains no chart data")
+	}
+
+	if release.Chart.Metadata != nil {
+		chartYAML, err := yaml.Marshal(release.Chart.Metadata)
+		if err != nil {
+			return fmt.Errorf("failed to marshal Chart.yaml: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), chartYAML, 0600); err != nil {
+			return fmt.Errorf("failed to write Chart.yaml: %w", err)
+		}
+	}
+
+	if release.Chart.Values != nil {
+		defaultValues, err := yaml.Marshal(release.Chart.Values)
+		if err != nil {
+			return fmt.Errorf("failed to marshal chart default values: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(chartDir, "values.yaml"), defaultValues, 0600); err != nil {
+			return fmt.Errorf("failed to write chart values.yaml: %w", err)
+		}
+	}
+
+	for _, tpl := range release.Chart.Templates {
+		dstPath := filepath.Join(chartDir, tpl.Name)
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
+			return fmt.Errorf("failed to create template directory for %s: %w", tpl.Name, err)
+		}
+		if err := os.WriteFile(dstPath, tpl.Data, 0600); err != nil {
+			return fmt.Errorf("failed to write template %s: %w", tpl.Name, err)
+		}
+	}
+
+	for _, f := range release.Chart.Files {
+		dstPath := filepath.Join(chartDir, f.Name)
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0700); err != nil {
+			return fmt.Errorf("failed to create chart file directory for %s: %w", f.Name, err)
+		}
+		if err := os.WriteFile(dstPath, f.Data, 0600); err != nil {
+			return fmt.Errorf("failed to write chart file %s: %w", f.Name, err)
+		}
+	}
+
+	return nil
+}
+
 func getFreePort() (int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/restore/deployer.go
+++ b/internal/restore/deployer.go
@@ -16,11 +16,13 @@ import (
 	"github.com/flightctl/flightctl/internal/backup"
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/yaml"
 )
 
 const dbDumpRelPath = "db/dump.sql"
@@ -140,6 +142,13 @@ type Deployer interface {
 	// running infrastructure. For Kubernetes, reads from cluster Secrets; for
 	// Podman, reads the service config file on the host.
 	GetConfig(ctx context.Context) (*config.Config, error)
+	// RestorePKI restores PKI materials from the extracted archive directory.
+	// For Podman, it copies <extractDir>/pki/ to the configured PKI destination
+	// (default: /etc/flightctl/pki/), preserving file permissions.
+	// For Kubernetes, it applies each <extractDir>/pki/*.yaml file as a Secret via the Go client (create or update).
+	// Returns an error if the pki/ subdirectory is absent from the archive.
+	// StopServices must be called before RestorePKI.
+	RestorePKI(ctx context.Context, extractDir string) error
 }
 
 // PodmanRestoreDeployer implements Deployer for Podman/quadlet deployments.
@@ -151,6 +160,7 @@ type PodmanRestoreDeployer struct {
 	serviceConfigPath string
 	dbName            string
 	kvContainerName   string
+	pkiDestPath       string
 	keepOldDB         bool
 	cachedCfg         *config.Config
 }
@@ -209,6 +219,14 @@ func WithKVContainerName(name string) PodmanRestoreOption {
 	}
 }
 
+// WithPKIDestPath sets the destination directory for PKI file restoration.
+// Defaults to /etc/flightctl/pki.
+func WithPKIDestPath(path string) PodmanRestoreOption {
+	return func(d *PodmanRestoreDeployer) {
+		d.pkiDestPath = path
+	}
+}
+
 // WithPodmanKeepOldDB controls whether the pre-restore database is dropped after
 // a successful swap (false, default) or preserved under <dbname>_old_<timestamp> (true).
 func WithPodmanKeepOldDB(keep bool) PodmanRestoreOption {
@@ -246,6 +264,9 @@ func NewPodmanRestoreDeployer(
 	}
 	if d.serviceConfigPath == "" {
 		d.serviceConfigPath = "/etc/flightctl/service-config.yaml"
+	}
+	if d.pkiDestPath == "" {
+		d.pkiDestPath = "/etc/flightctl/pki"
 	}
 	return d
 }
@@ -466,6 +487,61 @@ func parseContainerHostPort(output string) (host string, port int, ok bool) {
 		hostRaw = "127.0.0.1"
 	}
 	return hostRaw, int(p64), true
+}
+
+// RestorePKI copies the pki/ directory from the extracted archive into the configured
+// PKI destination, preserving each file's mode. Returns an error if pki/ is absent.
+func (p *PodmanRestoreDeployer) RestorePKI(ctx context.Context, extractDir string) error {
+	pkiSrcDir := filepath.Join(extractDir, "pki")
+	if _, err := os.Stat(pkiSrcDir); os.IsNotExist(err) {
+		return fmt.Errorf("PKI materials missing from archive: pki/ directory not found in %s", extractDir)
+	} else if err != nil {
+		return fmt.Errorf("failed to access PKI directory in archive: %w", err)
+	}
+
+	if err := os.MkdirAll(p.pkiDestPath, 0700); err != nil {
+		return fmt.Errorf("failed to create PKI destination directory %s: %w", p.pkiDestPath, err)
+	}
+
+	count := 0
+	err := filepath.Walk(pkiSrcDir, func(srcPath string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("error walking PKI source directory: %w", walkErr)
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		relPath, err := filepath.Rel(pkiSrcDir, srcPath)
+		if err != nil {
+			return fmt.Errorf("computing relative path for %s: %w", srcPath, err)
+		}
+		dstPath := filepath.Join(p.pkiDestPath, relPath)
+
+		if info.IsDir() {
+			if relPath == "." {
+				return nil
+			}
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("failed to read PKI file %s: %w", relPath, err)
+		}
+		if err := os.WriteFile(dstPath, data, info.Mode()); err != nil {
+			return fmt.Errorf("failed to write PKI file %s: %w", relPath, err)
+		}
+		p.log.Debugf("Restored PKI file: %s", relPath)
+		count++
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("PKI restore failed: %w", err)
+	}
+
+	p.log.Infof("PKI restore completed. Restored %d files to %s", count, p.pkiDestPath)
+	return nil
 }
 
 // KubernetesRestoreDeployer implements Deployer for Kubernetes/Helm deployments.
@@ -937,6 +1013,92 @@ func (k *KubernetesRestoreDeployer) ExposeService(ctx context.Context, serviceNa
 
 	k.log.Infof("Port-forwarding %s to localhost:%d", serviceName, localPort)
 	return "127.0.0.1", localPort, cleanup, nil
+}
+
+// RestorePKI reads each *.yaml file from the pki/ subdirectory of the extracted
+// archive and creates or updates the corresponding Kubernetes Secret via the Go
+// client. Returns an error if pki/ is absent or contains no YAML files.
+func (k *KubernetesRestoreDeployer) RestorePKI(ctx context.Context, extractDir string) error {
+	pkiSrcDir := filepath.Join(extractDir, "pki")
+	if _, err := os.Stat(pkiSrcDir); os.IsNotExist(err) {
+		return fmt.Errorf("PKI materials missing from archive: pki/ directory not found in %s", extractDir)
+	} else if err != nil {
+		return fmt.Errorf("failed to access PKI directory in archive: %w", err)
+	}
+
+	yamlFiles, err := filepath.Glob(filepath.Join(pkiSrcDir, "*.yaml"))
+	if err != nil {
+		return fmt.Errorf("failed to list PKI YAML files: %w", err)
+	}
+	if len(yamlFiles) == 0 {
+		return fmt.Errorf("PKI materials missing from archive: no Secret YAML files found in pki/ directory")
+	}
+
+	clientset, err := k.resolveClientset()
+	if err != nil {
+		return fmt.Errorf("failed to resolve Kubernetes clientset for PKI restore: %w", err)
+	}
+
+	for _, yamlPath := range yamlFiles {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("PKI restore cancelled: %w", err)
+		}
+		if err := k.applySecretFromFile(ctx, clientset, yamlPath); err != nil {
+			return fmt.Errorf("failed to apply PKI Secret %s: %w", filepath.Base(yamlPath), err)
+		}
+		k.log.Infof("Restored PKI Secret from %s", filepath.Base(yamlPath))
+	}
+
+	k.log.Infof("PKI restore completed. Applied %d Secrets", len(yamlFiles))
+	return nil
+}
+
+// applySecretFromFile reads a Secret YAML file, unmarshals it, and creates or
+// updates the Secret in the cluster. The namespace is taken from the YAML
+// metadata; if absent it falls back to k.namespace.
+// Server-assigned fields (ResourceVersion, UID, ManagedFields) are cleared so
+// that create and update both work regardless of prior cluster state.
+func (k *KubernetesRestoreDeployer) applySecretFromFile(ctx context.Context, clientset kubernetes.Interface, yamlPath string) error {
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var secret corev1.Secret
+	if err := yaml.Unmarshal(data, &secret); err != nil {
+		return fmt.Errorf("failed to unmarshal Secret YAML: %w", err)
+	}
+
+	ns := secret.Namespace
+	if ns == "" {
+		ns = k.namespace
+	}
+
+	// Clear server-assigned fields so the object can be created or updated
+	// without conflicts from stale metadata recorded at backup time.
+	secret.ResourceVersion = ""
+	secret.UID = ""
+	secret.Generation = 0
+	secret.ManagedFields = nil
+
+	_, err = clientset.CoreV1().Secrets(ns).Create(ctx, &secret, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create Secret %s/%s: %w", ns, secret.Name, err)
+	}
+
+	// Secret already exists — fetch its current ResourceVersion for the update.
+	existing, err := clientset.CoreV1().Secrets(ns).Get(ctx, secret.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get existing Secret %s/%s: %w", ns, secret.Name, err)
+	}
+	secret.ResourceVersion = existing.ResourceVersion
+	if _, err := clientset.CoreV1().Secrets(ns).Update(ctx, &secret, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update Secret %s/%s: %w", ns, secret.Name, err)
+	}
+	return nil
 }
 
 // getFreePort asks the OS for a free local TCP port by binding to :0.

--- a/internal/restore/deployer_test.go
+++ b/internal/restore/deployer_test.go
@@ -1,8 +1,12 @@
 package restore
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
 )
 
 // buildExtractDirWithDump creates an extract directory containing db/dump.sql
@@ -288,7 +293,7 @@ func TestPodmanRestoreDeployer_RestorePKI(t *testing.T) {
 			name: "When pki dir exists it should copy all files to destination",
 			setupDir: func(t *testing.T) string {
 				return buildExtractDirWithPKI(t, map[string]os.FileMode{
-					"ca.crt":    0600,
+					"ca.crt":     0600,
 					"server.key": 0600,
 				})
 			},
@@ -494,6 +499,267 @@ func TestKubernetesRestoreDeployer_RestorePKI(t *testing.T) {
 		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-ca", metav1.GetOptions{})
 		require.NoError(t, err)
 		require.Equal(t, []byte("new-cert"), got.Data["ca.crt"])
+	})
+}
+
+// buildExtractDirWithConfig creates an extract directory with a config/service-config.yaml
+// containing the given YAML content.
+func buildExtractDirWithConfig(t *testing.T, cfgContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	require.NoError(t, os.MkdirAll(cfgDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "service-config.yaml"), []byte(cfgContent), 0600))
+	return dir
+}
+
+// encodeHelmRelease encodes a helmReleaseJSON as base64(gzip(json)) — the format
+// Helm 3 uses when storing release data in a Kubernetes Secret.
+func encodeHelmRelease(t *testing.T, release helmReleaseJSON) []byte {
+	t.Helper()
+	releaseJSON, err := json.Marshal(release)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err = gw.Write(releaseJSON)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+
+	return []byte(base64.StdEncoding.EncodeToString(buf.Bytes()))
+}
+
+// buildExtractDirWithHelmSecret creates an extract directory with a
+// config/helm-release-<name>.yaml file containing a properly encoded Helm release Secret.
+func buildExtractDirWithHelmSecret(t *testing.T, release helmReleaseJSON, ns string) (string, kubernetes.Interface) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, "config")
+	require.NoError(t, os.MkdirAll(cfgDir, 0700))
+
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sh.helm.release.v1." + release.Name + ".v1",
+			Namespace: ns,
+			Labels:    map[string]string{"owner": "helm", "name": release.Name},
+		},
+		Data: map[string][]byte{"release": encodeHelmRelease(t, release)},
+		Type: "helm.sh/release.v1",
+	}
+	secretYAML, err := yaml.Marshal(secret)
+	require.NoError(t, err)
+	filename := "helm-release-" + release.Name + ".yaml"
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, filename), secretYAML, 0600))
+
+	return dir, fake.NewSimpleClientset()
+}
+
+// TestPodmanRestoreDeployer_RestoreConfig validates the behavioral contracts of
+// PodmanRestoreDeployer.RestoreConfig.
+func TestPodmanRestoreDeployer_RestoreConfig(t *testing.T) {
+	const cfgContent = "database:\n  hostname: testhost\n"
+
+	t.Run("When service-config.yaml is in the archive it should write it to the destination", func(t *testing.T) {
+		extractDir := buildExtractDirWithConfig(t, cfgContent)
+		destPath := filepath.Join(t.TempDir(), "service-config.yaml")
+
+		log, _ := test.NewNullLogger()
+		ctrl := gomock.NewController(t)
+		d := NewPodmanRestoreDeployer(log,
+			WithServiceHandler(NewMockServiceHandler(ctrl)),
+			WithServiceConfigPath(destPath),
+			WithContainerCLI("echo"),
+		)
+		require.NoError(t, d.RestoreConfig(context.Background(), extractDir))
+
+		content, err := os.ReadFile(destPath)
+		require.NoError(t, err)
+		require.Contains(t, string(content), "testhost")
+	})
+
+	t.Run("When service-config.yaml is absent from the archive it should return an error", func(t *testing.T) {
+		extractDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(extractDir, "config"), 0700))
+		destPath := filepath.Join(t.TempDir(), "service-config.yaml")
+
+		log, _ := test.NewNullLogger()
+		ctrl := gomock.NewController(t)
+		d := NewPodmanRestoreDeployer(log,
+			WithServiceHandler(NewMockServiceHandler(ctrl)),
+			WithServiceConfigPath(destPath),
+		)
+		err := d.RestoreConfig(context.Background(), extractDir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "service configuration not found in archive")
+	})
+
+	t.Run("When PAM Issuer volume archive is absent it should succeed", func(t *testing.T) {
+		extractDir := buildExtractDirWithConfig(t, cfgContent)
+		destPath := filepath.Join(t.TempDir(), "service-config.yaml")
+
+		log, _ := test.NewNullLogger()
+		ctrl := gomock.NewController(t)
+		d := NewPodmanRestoreDeployer(log,
+			WithServiceHandler(NewMockServiceHandler(ctrl)),
+			WithServiceConfigPath(destPath),
+		)
+		require.NoError(t, d.RestoreConfig(context.Background(), extractDir))
+	})
+
+	t.Run("When PAM Issuer volume import fails it should succeed with a warning", func(t *testing.T) {
+		extractDir := buildExtractDirWithConfig(t, cfgContent)
+		volumesDir := filepath.Join(extractDir, "volumes")
+		require.NoError(t, os.MkdirAll(volumesDir, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(volumesDir, "pam-issuer-etc.tar"), []byte("fake-tar"), 0600))
+		destPath := filepath.Join(t.TempDir(), "service-config.yaml")
+
+		log, _ := test.NewNullLogger()
+		ctrl := gomock.NewController(t)
+		d := NewPodmanRestoreDeployer(log,
+			WithServiceHandler(NewMockServiceHandler(ctrl)),
+			WithServiceConfigPath(destPath),
+			WithContainerCLI("/nonexistent-cli-for-testing"),
+		)
+		require.NoError(t, d.RestoreConfig(context.Background(), extractDir))
+	})
+
+	t.Run("When PAM Issuer volume import succeeds it should report success", func(t *testing.T) {
+		extractDir := buildExtractDirWithConfig(t, cfgContent)
+		volumesDir := filepath.Join(extractDir, "volumes")
+		require.NoError(t, os.MkdirAll(volumesDir, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(volumesDir, "pam-issuer-etc.tar"), []byte("fake-tar"), 0600))
+		destPath := filepath.Join(t.TempDir(), "service-config.yaml")
+
+		log, _ := test.NewNullLogger()
+		ctrl := gomock.NewController(t)
+		d := NewPodmanRestoreDeployer(log,
+			WithServiceHandler(NewMockServiceHandler(ctrl)),
+			WithServiceConfigPath(destPath),
+			WithContainerCLI("echo"),
+		)
+		require.NoError(t, d.RestoreConfig(context.Background(), extractDir))
+	})
+}
+
+// TestKubernetesRestoreDeployer_RestoreConfig validates the behavioral contracts of
+// KubernetesRestoreDeployer.RestoreConfig.
+func TestKubernetesRestoreDeployer_RestoreConfig(t *testing.T) {
+	const ns = "flightctl"
+
+	minimalRelease := helmReleaseJSON{
+		Name:      "flightctl",
+		Namespace: ns,
+		Chart: &helmChartJSON{
+			Metadata:  map[string]interface{}{"name": "flightctl", "version": "0.1.0"},
+			Templates: []*helmFileJSON{{Name: "templates/deploy.yaml", Data: []byte("---")}},
+		},
+		Config: map[string]interface{}{"replicaCount": 2},
+	}
+
+	t.Run("When config dir is absent it should return an error", func(t *testing.T) {
+		extractDir := t.TempDir()
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err := d.RestoreConfig(context.Background(), extractDir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to list config directory")
+	})
+
+	t.Run("When config dir is empty it should succeed without calling helm upgrade", func(t *testing.T) {
+		extractDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(extractDir, "config"), 0700))
+
+		upgradeCalled := false
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+			WithHelmUpgradeFunc(func(_ context.Context, _, _, _, _ string) error {
+				upgradeCalled = true
+				return nil
+			}),
+		)
+		require.NoError(t, d.RestoreConfig(context.Background(), extractDir))
+		require.False(t, upgradeCalled)
+	})
+
+	t.Run("When a Helm release Secret is present it should apply the Secret and run helm upgrade", func(t *testing.T) {
+		extractDir, cs := buildExtractDirWithHelmSecret(t, minimalRelease, ns)
+
+		var capturedRelease, capturedChartDir, capturedNS, capturedValues string
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+			WithHelmUpgradeFunc(func(_ context.Context, releaseName, chartDir, namespace, valuesFile string) error {
+				capturedRelease = releaseName
+				capturedChartDir = chartDir
+				capturedNS = namespace
+				capturedValues = valuesFile
+				return nil
+			}),
+		)
+		require.NoError(t, d.RestoreConfig(context.Background(), extractDir))
+
+		require.Equal(t, "flightctl", capturedRelease)
+		require.Equal(t, ns, capturedNS)
+		require.NotEmpty(t, capturedChartDir)
+		require.NotEmpty(t, capturedValues)
+
+		// Verify the Secret was applied to the cluster.
+		secrets, err := cs.CoreV1().Secrets(ns).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, secrets.Items)
+	})
+
+	t.Run("When helm upgrade fails it should return an error", func(t *testing.T) {
+		extractDir, cs := buildExtractDirWithHelmSecret(t, minimalRelease, ns)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+			WithHelmUpgradeFunc(func(_ context.Context, _, _, _, _ string) error {
+				return fmt.Errorf("helm upgrade: connection refused")
+			}),
+		)
+		err := d.RestoreConfig(context.Background(), extractDir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "helm upgrade")
+	})
+
+	t.Run("When Helm release chart and user values are present they should be written to the chart directory", func(t *testing.T) {
+		extractDir, cs := buildExtractDirWithHelmSecret(t, minimalRelease, ns)
+
+		// Inspect the chart dir and values file inside helmUpgradeFunc while they are
+		// still on disk (deferred cleanup runs after helmUpgradeFunc returns).
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+			WithHelmUpgradeFunc(func(_ context.Context, _, chartDir, _, valuesFile string) error {
+				_, err := os.Stat(filepath.Join(chartDir, "Chart.yaml"))
+				require.NoError(t, err)
+				_, err = os.Stat(filepath.Join(chartDir, "templates", "deploy.yaml"))
+				require.NoError(t, err)
+
+				valuesContent, err := os.ReadFile(valuesFile)
+				require.NoError(t, err)
+				require.Contains(t, string(valuesContent), "replicaCount")
+				return nil
+			}),
+		)
+		require.NoError(t, d.RestoreConfig(context.Background(), extractDir))
 	})
 }
 

--- a/internal/restore/deployer_test.go
+++ b/internal/restore/deployer_test.go
@@ -2,6 +2,7 @@ package restore
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
@@ -249,6 +251,250 @@ func TestKubernetesRestoreDeployer_GetConfig_MissingSecret(t *testing.T) {
 	_, err := d.GetConfig(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "flightctl-db-app-secret")
+}
+
+// buildExtractDirWithPKI creates an extract directory containing a pki/ subdirectory
+// with the given files (filename → mode). Returns the extract directory path.
+func buildExtractDirWithPKI(t *testing.T, files map[string]os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	pkiDir := filepath.Join(dir, "pki")
+	require.NoError(t, os.MkdirAll(pkiDir, 0700))
+	for name, mode := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(pkiDir, name), []byte("mock-pki-content"), mode))
+	}
+	return dir
+}
+
+// TestPodmanRestoreDeployer_RestorePKI validates the behavioral contracts
+// of PodmanRestoreDeployer.RestorePKI.
+func TestPodmanRestoreDeployer_RestorePKI(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupDir    func(t *testing.T) string
+		wantErr     bool
+		errContains string
+		verify      func(t *testing.T, destDir string)
+	}{
+		{
+			name: "When pki dir is absent from archive it should return error",
+			setupDir: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			wantErr:     true,
+			errContains: "pki",
+		},
+		{
+			name: "When pki dir exists it should copy all files to destination",
+			setupDir: func(t *testing.T) string {
+				return buildExtractDirWithPKI(t, map[string]os.FileMode{
+					"ca.crt":    0600,
+					"server.key": 0600,
+				})
+			},
+			verify: func(t *testing.T, destDir string) {
+				require.FileExists(t, filepath.Join(destDir, "ca.crt"))
+				require.FileExists(t, filepath.Join(destDir, "server.key"))
+				data, err := os.ReadFile(filepath.Join(destDir, "ca.crt"))
+				require.NoError(t, err)
+				require.Equal(t, "mock-pki-content", string(data))
+			},
+		},
+		{
+			name: "When pki dir exists it should preserve file permissions",
+			setupDir: func(t *testing.T) string {
+				return buildExtractDirWithPKI(t, map[string]os.FileMode{
+					"ca.crt": 0600,
+				})
+			},
+			verify: func(t *testing.T, destDir string) {
+				info, err := os.Stat(filepath.Join(destDir, "ca.crt"))
+				require.NoError(t, err)
+				require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+			},
+		},
+		{
+			name: "When pki dir contains subdirectories it should create them and copy nested files",
+			setupDir: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				subDir := filepath.Join(dir, "pki", "sub")
+				require.NoError(t, os.MkdirAll(subDir, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(subDir, "nested.crt"), []byte("nested-content"), 0600))
+				return dir
+			},
+			verify: func(t *testing.T, destDir string) {
+				data, err := os.ReadFile(filepath.Join(destDir, "sub", "nested.crt"))
+				require.NoError(t, err)
+				require.Equal(t, "nested-content", string(data))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, _ := test.NewNullLogger()
+			destDir := t.TempDir()
+			d := NewPodmanRestoreDeployer(log, WithPKIDestPath(destDir))
+			err := d.RestorePKI(context.Background(), tt.setupDir(t))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.verify != nil {
+				tt.verify(t, destDir)
+			}
+		})
+	}
+}
+
+// buildExtractDirWithPKISecrets creates an extract directory with a pki/
+// subdirectory containing one YAML file per Secret (serialised as JSON,
+// which is valid YAML). Returns the extract directory and the fake clientset
+// that can be used to verify post-restore cluster state.
+func buildExtractDirWithPKISecrets(t *testing.T, secrets []*corev1.Secret) (string, kubernetes.Interface) {
+	t.Helper()
+	dir := t.TempDir()
+	pkiDir := filepath.Join(dir, "pki")
+	require.NoError(t, os.MkdirAll(pkiDir, 0700))
+	for _, s := range secrets {
+		data, err := json.Marshal(s)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(pkiDir, s.Name+".yaml"), data, 0600))
+	}
+	return dir, fake.NewSimpleClientset()
+}
+
+// TestKubernetesRestoreDeployer_RestorePKI validates the behavioral contracts
+// of KubernetesRestoreDeployer.RestorePKI.
+func TestKubernetesRestoreDeployer_RestorePKI(t *testing.T) {
+	const ns = "flightctl"
+
+	t.Run("When pki dir is absent from archive it should return error", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err := d.RestorePKI(context.Background(), t.TempDir())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "pki")
+	})
+
+	t.Run("When pki dir exists with no yaml files it should return error", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		extractDir := buildExtractDirWithPKI(t, map[string]os.FileMode{})
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err := d.RestorePKI(context.Background(), extractDir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no Secret YAML files")
+	})
+
+	t.Run("When pki dir exists with yaml files it should create each Secret in the cluster", func(t *testing.T) {
+		secrets := []*corev1.Secret{
+			{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+				ObjectMeta: metav1.ObjectMeta{Name: "flightctl-ca", Namespace: ns},
+				Data:       map[string][]byte{"ca.crt": []byte("mock-cert")},
+			},
+			{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+				ObjectMeta: metav1.ObjectMeta{Name: "flightctl-api-server-tls", Namespace: ns},
+				Data:       map[string][]byte{"tls.crt": []byte("mock-tls")},
+			},
+		}
+		extractDir, cs := buildExtractDirWithPKISecrets(t, secrets)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestorePKI(context.Background(), extractDir))
+
+		for _, s := range secrets {
+			got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), s.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, s.Name, got.Name)
+		}
+	})
+
+	t.Run("When yaml file contains invalid content it should return an error", func(t *testing.T) {
+		dir := t.TempDir()
+		pkiDir := filepath.Join(dir, "pki")
+		require.NoError(t, os.MkdirAll(pkiDir, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(pkiDir, "bad.yaml"), []byte("{not: valid: yaml: ["), 0600))
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(fake.NewSimpleClientset()),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		err := d.RestorePKI(context.Background(), dir)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to apply PKI Secret")
+	})
+
+	t.Run("When secret yaml has no namespace it should use the deployer namespace", func(t *testing.T) {
+		secret := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-ca"},
+			Data:       map[string][]byte{"ca.crt": []byte("cert")},
+		}
+		extractDir, cs := buildExtractDirWithPKISecrets(t, []*corev1.Secret{secret})
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestorePKI(context.Background(), extractDir))
+
+		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-ca", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "flightctl-ca", got.Name)
+	})
+
+	t.Run("When yaml file contains an existing secret it should update the cluster secret", func(t *testing.T) {
+		existing := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-ca", Namespace: ns},
+			Data:       map[string][]byte{"ca.crt": []byte("old-cert")},
+		}
+		updated := &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: "flightctl-ca", Namespace: ns},
+			Data:       map[string][]byte{"ca.crt": []byte("new-cert")},
+		}
+		extractDir, cs := buildExtractDirWithPKISecrets(t, []*corev1.Secret{updated})
+		_, err := cs.CoreV1().Secrets(ns).Create(context.Background(), existing, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		log, _ := test.NewNullLogger()
+		d := NewKubernetesRestoreDeployer(log,
+			WithRestoreNamespace(ns),
+			WithRestoreClientset(cs),
+			WithRestoreRestConfig(&rest.Config{}),
+		)
+		require.NoError(t, d.RestorePKI(context.Background(), extractDir))
+
+		got, err := cs.CoreV1().Secrets(ns).Get(context.Background(), "flightctl-ca", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, []byte("new-cert"), got.Data["ca.crt"])
+	})
 }
 
 // TestKubernetesRestoreDeployer_GetConfig_Success validates credential extraction

--- a/internal/restore/mock_deployer.go
+++ b/internal/restore/mock_deployer.go
@@ -124,6 +124,20 @@ func (mr *MockDeployerMockRecorder) GetConfig(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockDeployer)(nil).GetConfig), ctx)
 }
 
+// RestoreConfig mocks base method.
+func (m *MockDeployer) RestoreConfig(ctx context.Context, extractDir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreConfig", ctx, extractDir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreConfig indicates an expected call of RestoreConfig.
+func (mr *MockDeployerMockRecorder) RestoreConfig(ctx, extractDir any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreConfig", reflect.TypeOf((*MockDeployer)(nil).RestoreConfig), ctx, extractDir)
+}
+
 // RestoreDatabase mocks base method.
 func (m *MockDeployer) RestoreDatabase(ctx context.Context, extractDir string) error {
 	m.ctrl.T.Helper()

--- a/internal/restore/mock_deployer.go
+++ b/internal/restore/mock_deployer.go
@@ -138,6 +138,20 @@ func (mr *MockDeployerMockRecorder) RestoreDatabase(ctx, extractDir any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreDatabase", reflect.TypeOf((*MockDeployer)(nil).RestoreDatabase), ctx, extractDir)
 }
 
+// RestorePKI mocks base method.
+func (m *MockDeployer) RestorePKI(ctx context.Context, extractDir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestorePKI", ctx, extractDir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestorePKI indicates an expected call of RestorePKI.
+func (mr *MockDeployerMockRecorder) RestorePKI(ctx, extractDir any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestorePKI", reflect.TypeOf((*MockDeployer)(nil).RestorePKI), ctx, extractDir)
+}
+
 // StartServices mocks base method.
 func (m *MockDeployer) StartServices(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -23,12 +23,11 @@ const startServicesTimeout = 2 * time.Minute
 //  5. Stops FlightCtl services (deployer.StopServices)
 //  6. Imports the database (deployer.RestoreDatabase)
 //  7. Restores PKI materials (deployer.RestorePKI)
-//  8. Retrieves service credentials via deployer.GetConfig
-//  9. Exposes DB and KV via deployer.ExposeService (no-op for Podman, port-forward for Kubernetes)
-//
-// 10. Runs post-restoration device preparation (PrepareDevices)
-//
-// 11. Starts FlightCtl services (deployer.StartServices) — deferred, always runs even on failure
+//  8. Restores service configuration (deployer.RestoreConfig)
+//  9. Retrieves service credentials via deployer.GetConfig
+//  10. Exposes DB and KV via deployer.ExposeService (no-op for Podman, port-forward for Kubernetes)
+//  11. Runs post-restoration device preparation (PrepareDevices)
+//  12. Starts FlightCtl services (deployer.StartServices) — deferred, always runs even on failure
 //
 // The deployer encapsulates all deployment-specific operations and credential extraction.
 // The temporary extraction directory is always cleaned up before Restore returns.
@@ -108,6 +107,12 @@ func Restore(
 		return fmt.Errorf("PKI restore failed: %w", err)
 	}
 	log.Info("PKI restore completed")
+
+	log.Info("Restoring service configuration")
+	if err := deployer.RestoreConfig(ctx, extractDir); err != nil {
+		return fmt.Errorf("service configuration restore failed: %w", err)
+	}
+	log.Info("Service configuration restore completed")
 
 	log.Info("Retrieving service credentials from infrastructure")
 	cfg, err := deployer.GetConfig(ctx)

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -22,11 +22,13 @@ const startServicesTimeout = 2 * time.Minute
 //  4. Validates the archive's deployment type against deployer.Type() (ValidateDeploymentType)
 //  5. Stops FlightCtl services (deployer.StopServices)
 //  6. Imports the database (deployer.RestoreDatabase)
-//  7. Retrieves service credentials via deployer.GetConfig
-//  8. Exposes DB and KV via deployer.ExposeService (no-op for Podman, port-forward for Kubernetes)
-//  9. Runs post-restoration device preparation (PrepareDevices)
+//  7. Restores PKI materials (deployer.RestorePKI)
+//  8. Retrieves service credentials via deployer.GetConfig
+//  9. Exposes DB and KV via deployer.ExposeService (no-op for Podman, port-forward for Kubernetes)
 //
-// 10. Starts FlightCtl services (deployer.StartServices) — deferred, always runs even on failure
+// 10. Runs post-restoration device preparation (PrepareDevices)
+//
+// 11. Starts FlightCtl services (deployer.StartServices) — deferred, always runs even on failure
 //
 // The deployer encapsulates all deployment-specific operations and credential extraction.
 // The temporary extraction directory is always cleaned up before Restore returns.
@@ -100,6 +102,12 @@ func Restore(
 		return fmt.Errorf("database restore failed: %w", err)
 	}
 	log.Info("Database restore completed")
+
+	log.Info("Restoring PKI materials")
+	if err := deployer.RestorePKI(ctx, extractDir); err != nil {
+		return fmt.Errorf("PKI restore failed: %w", err)
+	}
+	log.Info("PKI restore completed")
 
 	log.Info("Retrieving service credentials from infrastructure")
 	cfg, err := deployer.GetConfig(ctx)

--- a/test/integration/restore/config_test.go
+++ b/test/integration/restore/config_test.go
@@ -1,0 +1,198 @@
+package restore_test
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/flightctl/flightctl/internal/restore"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/test/harness/containers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+// buildTestExtractDirWithServiceConfig writes config/service-config.yaml with the
+// given content into extractDir.
+func buildTestExtractDirWithServiceConfig(extractDir, cfgContent string) {
+	cfgDir := filepath.Join(extractDir, "config")
+	Expect(os.MkdirAll(cfgDir, 0700)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(cfgDir, "service-config.yaml"), []byte(cfgContent), 0600)).To(Succeed())
+}
+
+// buildTestExtractDirWithSyntheticPAMVolume creates a minimal valid tar file at
+// <extractDir>/volumes/pam-issuer-etc.tar containing a single file named filename.
+// The tar is crafted entirely in Go so no running Podman volume is needed during setup.
+func buildTestExtractDirWithSyntheticPAMVolume(extractDir, filename string) {
+	volumesDir := filepath.Join(extractDir, "volumes")
+	Expect(os.MkdirAll(volumesDir, 0700)).To(Succeed())
+
+	tarPath := filepath.Join(volumesDir, "pam-issuer-etc.tar")
+	f, err := os.Create(tarPath)
+	Expect(err).NotTo(HaveOccurred())
+	defer f.Close()
+
+	tw := tar.NewWriter(f)
+	defer tw.Close()
+
+	content := []byte("test content for " + filename)
+	hdr := &tar.Header{
+		Name: filename,
+		Mode: 0600,
+		Size: int64(len(content)),
+	}
+	Expect(tw.WriteHeader(hdr)).To(Succeed())
+	_, err = tw.Write(content)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// podmanVolumeMountpoint returns the storage path for a named Podman volume.
+func podmanVolumeMountpoint(ctx context.Context, cli, volumeName string) (string, error) {
+	out, err := exec.CommandContext(ctx, cli, "volume", "inspect", volumeName, "--format", "{{.Mountpoint}}").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// cleanupVolume removes a Podman volume created during the test.
+func cleanupVolume(cli, volumeName string) {
+	_ = exec.Command(cli, "volume", "rm", "--force", volumeName).Run() //nolint:gosec
+}
+
+var _ = Describe("PodmanRestoreDeployer RestoreConfig", func() {
+	const minimalCfg = "database:\n  hostname: testhost\n"
+
+	var (
+		ctx        context.Context
+		log        *logrus.Logger
+		extractDir string
+		cli        string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		log = flightlog.InitLogs()
+		cli = containers.RuntimeCLIName()
+
+		var err error
+		extractDir, err = os.MkdirTemp("", "restore-config-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(extractDir)
+	})
+
+	It("When a service-config.yaml is in the archive it should write it to the destination", func() {
+		buildTestExtractDirWithServiceConfig(extractDir, minimalCfg)
+
+		destDir, err := os.MkdirTemp("", "restore-config-dest-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(destDir) })
+		destPath := filepath.Join(destDir, "service-config.yaml")
+
+		d := restore.NewPodmanRestoreDeployer(log,
+			restore.WithServiceHandler(restore.NewSystemctlServiceHandler([]string{})),
+			restore.WithServiceConfigPath(destPath),
+			restore.WithContainerCLI(cli),
+		)
+		Expect(d.RestoreConfig(ctx, extractDir)).To(Succeed())
+		Expect(destPath).To(BeAnExistingFile())
+
+		content, err := os.ReadFile(destPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(ContainSubstring("testhost"))
+	})
+
+	It("When a PAM Issuer volume archive is in the archive it should import it into the named volume", func() {
+		volumeName := fmt.Sprintf("flightctl-test-pam-issuer-%d", GinkgoRandomSeed())
+		DeferCleanup(func() { cleanupVolume(cli, volumeName) })
+
+		buildTestExtractDirWithServiceConfig(extractDir, minimalCfg)
+		buildTestExtractDirWithSyntheticPAMVolume(extractDir, "marker-a.txt")
+
+		destDir, err := os.MkdirTemp("", "restore-config-dest-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(destDir) })
+		destPath := filepath.Join(destDir, "service-config.yaml")
+
+		d := restore.NewPodmanRestoreDeployer(log,
+			restore.WithServiceHandler(restore.NewSystemctlServiceHandler([]string{})),
+			restore.WithServiceConfigPath(destPath),
+			restore.WithContainerCLI(cli),
+			restore.WithPAMIssuerVolumeName(volumeName),
+		)
+		Expect(d.RestoreConfig(ctx, extractDir)).To(Succeed())
+
+		// Volume must have been created and populated by the import.
+		mountpoint, err := podmanVolumeMountpoint(ctx, cli, volumeName)
+		Expect(err).NotTo(HaveOccurred(), "volume should exist after import")
+		Expect(filepath.Join(mountpoint, "marker-a.txt")).To(BeAnExistingFile())
+	})
+
+	It("When the PAM Issuer volume already exists it should overwrite it with the archive content", func() {
+		volumeName := fmt.Sprintf("flightctl-test-pam-issuer-exists-%d", GinkgoRandomSeed())
+		DeferCleanup(func() { cleanupVolume(cli, volumeName) })
+
+		// First restore — import old content into a fresh volume.
+		buildTestExtractDirWithServiceConfig(extractDir, minimalCfg)
+		buildTestExtractDirWithSyntheticPAMVolume(extractDir, "old-marker.txt")
+
+		firstDestDir, err := os.MkdirTemp("", "restore-config-dest-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(firstDestDir) })
+
+		d := restore.NewPodmanRestoreDeployer(log,
+			restore.WithServiceHandler(restore.NewSystemctlServiceHandler([]string{})),
+			restore.WithServiceConfigPath(filepath.Join(firstDestDir, "service-config.yaml")),
+			restore.WithContainerCLI(cli),
+			restore.WithPAMIssuerVolumeName(volumeName),
+		)
+		Expect(d.RestoreConfig(ctx, extractDir)).To(Succeed())
+
+		// Second restore — overwrite the volume with new content.
+		secondExtractDir, err := os.MkdirTemp("", "restore-config-overwrite-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(secondExtractDir) })
+
+		buildTestExtractDirWithServiceConfig(secondExtractDir, minimalCfg)
+		buildTestExtractDirWithSyntheticPAMVolume(secondExtractDir, "new-marker.txt")
+
+		secondDestDir, err := os.MkdirTemp("", "restore-config-dest2-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(secondDestDir) })
+
+		d2 := restore.NewPodmanRestoreDeployer(log,
+			restore.WithServiceHandler(restore.NewSystemctlServiceHandler([]string{})),
+			restore.WithServiceConfigPath(filepath.Join(secondDestDir, "service-config.yaml")),
+			restore.WithContainerCLI(cli),
+			restore.WithPAMIssuerVolumeName(volumeName),
+		)
+		Expect(d2.RestoreConfig(ctx, secondExtractDir)).To(Succeed())
+
+		mountpoint, err := podmanVolumeMountpoint(ctx, cli, volumeName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filepath.Join(mountpoint, "new-marker.txt")).To(BeAnExistingFile())
+	})
+
+	It("When the PAM volume archive is absent it should succeed", func() {
+		buildTestExtractDirWithServiceConfig(extractDir, minimalCfg)
+
+		destDir, err := os.MkdirTemp("", "restore-config-dest-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(destDir) })
+
+		d := restore.NewPodmanRestoreDeployer(log,
+			restore.WithServiceHandler(restore.NewSystemctlServiceHandler([]string{})),
+			restore.WithServiceConfigPath(filepath.Join(destDir, "service-config.yaml")),
+			restore.WithContainerCLI(cli),
+		)
+		Expect(d.RestoreConfig(ctx, extractDir)).To(Succeed())
+	})
+})


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
