### PR TITLE
NO-ISSUE: extract simulated agent helpers into test/util

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"math/rand/v2"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -20,7 +19,6 @@ import (
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent"
 	agent_config "github.com/flightctl/flightctl/internal/agent/config"
-	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
 	baseclient "github.com/flightctl/flightctl/internal/client"
@@ -248,23 +246,15 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 }
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
-		log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
-		bannerFileData, err := readBannerFile(agentDir)
-		if err != nil {
-			return false, nil
+	log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, 5*time.Second, 5*time.Minute)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Errorf("Error waiting for enrollment request: %v", err)
 		}
-		enrollmentID := testutil.GetEnrollmentIdFromText(bannerFileData)
-		if enrollmentID == "" {
-			log.Warnf("No enrollment id found in banner file %s", bannerFileData)
-			return false, nil
-		}
-		log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
-		return true, nil
-	})
-	if err != nil && ctx.Err() == nil {
-		log.Errorf("Error waiting for enrollment request: %v", err)
+		return
 	}
+	log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
 }
 
 func reportVersion(versionFormat *string) error {
@@ -471,80 +461,27 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 			enrollmentTransport,
 		)
 
-		if err := cfg.Complete(); err != nil {
+		cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
+		agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName)
+		if err != nil {
 			logger.Fatalf("agent config %d: %v", i, err)
 		}
-		if err := cfg.Validate(); err != nil {
-			logger.Fatalf("agent config %d: %v", i, err)
-		}
-
-		logWithPrefix := flightlog.NewPrefixLogger(agentName)
-		logWithPrefix.Level(agentCfg.agentConfigTemplate.LogLevel)
-		agents[i] = agent.New(logWithPrefix, cfg, "")
+		agents[i] = agentInstance
 		agentsFolders[i] = agentDir
 	}
 	return agents, agentsFolders
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
-	enrollmentId := ""
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
-		log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
-		if enrollmentId == "" {
-			bannerFileData, err := readBannerFile(agentDir)
-			if err != nil {
-				log.Warnf("Error reading banner file: %v", err)
-				return false, nil
-			}
-			enrollmentId = testutil.GetEnrollmentIdFromText(bannerFileData)
-			if enrollmentId == "" {
-				log.Warnf("No enrollment id found in banner file %s", bannerFileData)
-				return false, nil
-			}
-		}
-		// timeout after 30s and retry
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-		resp, err := serviceClient.ApproveEnrollmentRequestWithResponse(
-			ctx,
-			enrollmentId,
-			v1beta1.EnrollmentRequestApproval{
-				Approved: true,
-				Labels:   labels,
-			})
-		if err != nil {
-			log.Errorf("Error approving device %s enrollment: %v", enrollmentId, err)
-			return false, nil
-		}
-		responseCode := resp.StatusCode()
-		if responseCode == http.StatusNotFound {
-			// no error, but don't log this. There could be a race condition in posting vs approving and is not exceptional
-			return false, nil
-		}
-		if responseCode < http.StatusOK || responseCode >= http.StatusMultipleChoices {
-			log.Warnf("Failed approving device %s enrollment: %d", enrollmentId, responseCode)
-			return false, nil
-		}
-		log.Infof("Approved device enrollment %s", enrollmentId)
-		return true, nil
-	})
-	if err != nil && ctx.Err() == nil {
-		log.Errorf("Error approving device enrollment: %v", err)
-	}
-}
-
-func readBannerFile(agentDir string) (string, error) {
-	var data []byte
-	var err error
-	bannerFile := filepath.Join(agentDir, lifecycle.BannerFile)
-	if _, err = os.Stat(bannerFile); err != nil {
-		return "", err
-	}
-	data, err = os.ReadFile(bannerFile)
+	log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, 5*time.Second, 5*time.Minute)
 	if err != nil {
-		return "", err
+		if ctx.Err() == nil {
+			log.Errorf("Error approving device enrollment: %v", err)
+		}
+		return
 	}
-	return string(data), nil
+	log.Infof("Approved device enrollment %s", enrollmentID)
 }
 
 func copyFile(from, to string) error {

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -452,11 +452,13 @@ func (h *TestHarness) StopAgent() {
 }
 
 func (h *TestHarness) StartAgent() {
-	agentLog := log.NewPrefixLogger("")
-
 	// Use SafeExecuter in tests to prevent dangerous commands like systemctl reboot
 	safeExec := testutil.NewDefaultSafeExecuter()
-	agentInstance := agent.New(agentLog, h.agentConfig, "", agent.WithExecuter(safeExec))
+	agentInstance, err := testutil.NewSimulatedAgent(h.agentConfig, "", agent.WithExecuter(safeExec))
+	if err != nil {
+		h.goRoutineErrorHandler(fmt.Errorf("error constructing agent: %w", err))
+		return
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	h.agentFinished = make(chan struct{})

--- a/test/util/simagent.go
+++ b/test/util/simagent.go
@@ -1,0 +1,105 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent"
+	agent_config "github.com/flightctl/flightctl/internal/agent/config"
+	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// NewSimulatedAgent finalizes cfg (Complete + Validate) and constructs the corresponding agent.Agent
+// with a prefixed logger. This consolidates the setup sequence previously duplicated between
+// devicesimulator and integration test harnesses.
+func NewSimulatedAgent(cfg *agent_config.Config, name string, opts ...agent.AgentOption) (*agent.Agent, error) {
+	if err := cfg.Complete(); err != nil {
+		return nil, fmt.Errorf("completing agent config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validating agent config: %w", err)
+	}
+	logWithPrefix := flightlog.NewPrefixLogger(name)
+	if cfg.LogLevel != "" {
+		logWithPrefix.Level(cfg.LogLevel)
+	}
+	return agent.New(logWithPrefix, cfg, "", opts...), nil
+}
+
+// ReadBannerFile reads the enrollment banner file written by the agent's lifecycle manager under agentDir.
+func ReadBannerFile(agentDir string) (string, error) {
+	bannerFile := filepath.Join(agentDir, lifecycle.BannerFile)
+	if _, err := os.Stat(bannerFile); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(bannerFile)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WaitForEnrollmentID polls agentDir's banner file until an enrollment ID appears, the context is
+// cancelled, or timeout elapses. Returns the discovered enrollment ID (empty if never found) and
+// the poll error, if any.
+func WaitForEnrollmentID(ctx context.Context, agentDir string, pollInterval, timeout time.Duration) (string, error) {
+	enrollmentID := ""
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+		bannerFileData, err := ReadBannerFile(agentDir)
+		if err != nil {
+			return false, nil
+		}
+		enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+		return enrollmentID != "", nil
+	})
+	return enrollmentID, err
+}
+
+// ApproveEnrollment polls agentDir's banner file for the enrollment ID and repeatedly attempts to
+// approve it via serviceClient until it succeeds, the context is cancelled, or timeout elapses.
+// Returns the discovered enrollment ID (empty if never found) and a terminal error (nil on success).
+func ApproveEnrollment(ctx context.Context, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string, pollInterval, timeout time.Duration) (string, error) {
+	enrollmentID := ""
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+		if enrollmentID == "" {
+			bannerFileData, err := ReadBannerFile(agentDir)
+			if err != nil {
+				return false, nil
+			}
+			enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+			if enrollmentID == "" {
+				return false, nil
+			}
+		}
+		approveCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		resp, err := serviceClient.ApproveEnrollmentRequestWithResponse(
+			approveCtx,
+			enrollmentID,
+			v1beta1.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   labels,
+			})
+		if err != nil {
+			return false, nil
+		}
+		code := resp.StatusCode()
+		if code == http.StatusNotFound {
+			// no error, but don't treat as exceptional: there can be a race between posting and approving
+			return false, nil
+		}
+		if code < http.StatusOK || code >= http.StatusMultipleChoices {
+			return false, nil
+		}
+		return true, nil
+	})
+	return enrollmentID, err
+}


### PR DESCRIPTION
## Summary
- Extract `NewSimulatedAgent`, `ReadBannerFile`, `WaitForEnrollmentID`, and `ApproveEnrollment` into `test/util/simagent.go`
- Wire `devicesimulator` and the integration test harness through the shared helpers

## Stack
Layer 1/7 on top of `EDM-4335-status-update-optimizations` (PR #3288).

## Test plan
- [ ] `go build ./cmd/devicesimulator/... ./test/util/... ./test/harness/...`

Made with [Cursor](https://cursor.com)