### PR TITLE
NO-ISSUE: add devicesimulator enrollment metrics and error reasons

### DIFF
--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -150,6 +150,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not parse config file: %v", err)
 	}
+	if cfg.Organization != "" {
+		log.Infof("using organization %s from client config", cfg.Organization)
+	} else {
+		log.Infoln("no organization set in client config")
+	}
 	// allow many idle conns to prevent tearing down connections we may need again
 	cfg.AddHTTPOptions(client.WithMaxIdleConnsPerHost(*maxConcurrency))
 	serviceClient, err := client.NewFromConfig(cfg, baseDir)
@@ -248,6 +253,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
 	log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
 	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, 5*time.Second, 5*time.Minute)
+	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
 			log.Errorf("Error waiting for enrollment request: %v", err)
@@ -477,6 +483,7 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
 	log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
 	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, 5*time.Second, 5*time.Minute)
+	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
 			log.Errorf("Error approving device enrollment: %v", err)

--- a/cmd/devicesimulator/prometheus.go
+++ b/cmd/devicesimulator/prometheus.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
@@ -51,6 +56,15 @@ var (
 		},
 		[]string{"operation", "result"},
 	)
+	enrollmentOutcomes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "enrollment_outcomes_total",
+			Help:      "Total enrollment wait/approve outcomes, partitioned by result",
+		},
+		[]string{"result"},
+	)
 )
 
 func setupMetricsEndpoint(metricsAddress string) {
@@ -66,6 +80,7 @@ func setupMetricsEndpoint(metricsAddress string) {
 	prometheus.MustRegister(apiRequests)
 	prometheus.MustRegister(apiErrors)
 	prometheus.MustRegister(apiRequestDurations)
+	prometheus.MustRegister(enrollmentOutcomes)
 }
 
 func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {
@@ -80,6 +95,48 @@ func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {
 }
 
 func reasonFromAPIError(err error) string {
-	errorType := "unknown"
-	return errorType
+	if err == nil {
+		return "unknown"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		msg := opErr.Error()
+		if strings.Contains(msg, "cannot assign requested address") {
+			return "bind"
+		}
+		if opErr.Op == "dial" {
+			return "dial"
+		}
+		return "connection"
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "cannot assign requested address") {
+		return "bind"
+	}
+	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "connection reset") {
+		return "connection"
+	}
+	if strings.Contains(msg, "dial ") {
+		return "dial"
+	}
+	return "unknown"
+}
+
+func recordEnrollmentOutcome(ctx context.Context, err error) {
+	switch {
+	case err == nil:
+		enrollmentOutcomes.WithLabelValues("approved").Inc()
+	case ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled):
+		enrollmentOutcomes.WithLabelValues("cancelled").Inc()
+	case wait.Interrupted(err) || errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded):
+		enrollmentOutcomes.WithLabelValues("timeout").Inc()
+	default:
+		enrollmentOutcomes.WithLabelValues("error").Inc()
+	}
 }


### PR DESCRIPTION
## Summary
- Track enrollment wait/approve outcomes via Prometheus
- Classify RPC errors (timeout/dial/bind/connection) instead of always `unknown`
- Log resolved organization from client config at startup

## Stack
Layer 3/7. Depends on devicesim-persistence.

## Test plan
- [ ] Hit `/metrics` during a run and confirm `enrollment_outcomes_total` and classified `api_errors_total`

Made with [Cursor](https://cursor.com)