### PR TITLE
NO-ISSUE: add devicesimulator fleet distribution

### DIFF
--- a/cmd/devicesimulator/fleets.go
+++ b/cmd/devicesimulator/fleets.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/sirupsen/logrus"
+)
+
+func scaleFleetNames(prefix string, count int) []string {
+	names := make([]string, count)
+	for i := 0; i < count; i++ {
+		names[i] = fmt.Sprintf("%s-%02d", prefix, i)
+	}
+	return names
+}
+
+func createScaleFleets(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, prefix string, count int) ([]string, error) {
+	names := scaleFleetNames(prefix, count)
+	for _, name := range names {
+		response, err := serviceClient.GetFleetWithResponse(ctx, name, &v1beta1.GetFleetParams{})
+		if err == nil && response.HTTPResponse != nil && response.HTTPResponse.StatusCode == http.StatusOK {
+			log.Infof("Fleet %s already exists, skipping creation", name)
+			continue
+		}
+
+		fleet, err := newScaleFleet(name)
+		if err != nil {
+			return nil, fmt.Errorf("building fleet %s: %w", name, err)
+		}
+		fleetJSON, err := json.Marshal(fleet)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling fleet %s: %w", name, err)
+		}
+		createResponse, err := serviceClient.ReplaceFleetWithBodyWithResponse(ctx, name, "application/json", bytes.NewReader(fleetJSON))
+		if err != nil {
+			return nil, fmt.Errorf("creating fleet %s: %w", name, err)
+		}
+		if createResponse.StatusCode() < http.StatusOK || createResponse.StatusCode() >= http.StatusMultipleChoices {
+			return nil, fmt.Errorf("creating fleet %s: status %d, body: %s", name, createResponse.StatusCode(), string(createResponse.Body))
+		}
+		log.Infof("Successfully created fleet: %s", name)
+	}
+	return names, nil
+}
+
+func newScaleFleet(name string) (*v1beta1.Fleet, error) {
+	mode := 0644
+	content := fmt.Sprintf("This system is managed by flightctl (fleet %s).", name)
+	var configItem v1beta1.ConfigProviderSpec
+	if err := configItem.FromInlineConfigProviderSpec(v1beta1.InlineConfigProviderSpec{
+		Name: "motd-update",
+		Inline: []v1beta1.FileSpec{
+			{
+				Path:    "/etc/motd",
+				Content: content,
+				Mode:    &mode,
+			},
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	matchLabels := map[string]string{"fleet": name}
+	templateLabels := map[string]string{"fleet": name}
+	return &v1beta1.Fleet{
+		ApiVersion: v1beta1.ApiVersion("flightctl.io/v1beta1"),
+		Kind:       v1beta1.FleetKind,
+		Metadata: v1beta1.ObjectMeta{
+			Name: &name,
+		},
+		Spec: v1beta1.FleetSpec{
+			Selector: &v1beta1.LabelSelector{
+				MatchLabels: &matchLabels,
+			},
+			Template: struct {
+				Metadata *v1beta1.ObjectMeta `json:"metadata,omitempty"`
+				Spec     v1beta1.DeviceSpec  `json:"spec"`
+			}{
+				Metadata: &v1beta1.ObjectMeta{
+					Labels: &templateLabels,
+				},
+				Spec: v1beta1.DeviceSpec{
+					Config: &[]v1beta1.ConfigProviderSpec{configItem},
+				},
+			},
+		},
+	}, nil
+}

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -78,6 +78,8 @@ func main() {
 	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
 	clean := pflag.Bool("clean", false, "wipe local simulator state and delete simulator-created devices/enrollment requests before starting")
 	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
+	fleetCount := pflag.Int("fleet-count", 0, "number of scale fleets to create and distribute devices across (0 disables)")
+	fleetPrefix := pflag.String("fleet-prefix", "scale-fleet", "prefix for scale fleet names (<prefix>-NN)")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -182,12 +184,19 @@ func main() {
 
 	log.Infoln("creating agents")
 
-	// Create simulator fleet configuration
-	if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
+	var fleetNames []string
+	if *fleetCount > 0 {
+		log.Infof("skipping default simulator-disk-monitoring fleet because --fleet-count=%d", *fleetCount)
+		var err error
+		fleetNames, err = createScaleFleets(ctx, log, serviceClient.ClientWithResponses, *fleetPrefix, *fleetCount)
+		if err != nil {
+			log.Fatalf("Failed to create scale fleets: %v", err)
+		}
+	} else if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
 		log.Warnf("Failed to create simulator fleet: %v", err)
 	}
 
-	agents, agentsFolders := createAgents(createAgentsConfig{
+	agents, agentsFolders, perAgentLabels := createAgents(createAgentsConfig{
 		log:                 log,
 		numDevices:          *numDevices,
 		initialDeviceIndex:  *initialDeviceIndex,
@@ -195,6 +204,7 @@ func main() {
 		parsedSourceIPs:     parsedSourceIPs,
 		maxConcurrency:      *maxConcurrency,
 		simulatorLabels:     formattedLables,
+		fleetNames:          fleetNames,
 	})
 
 	sigShutdown := make(chan os.Signal, 1)
@@ -221,7 +231,7 @@ func main() {
 		agentFolders:    agentsFolders,
 		log:             log,
 		serviceClient:   serviceClient.ClientWithResponses,
-		formattedLabels: formattedLables,
+		perAgentLabels:  perAgentLabels,
 		sem:             sem,
 		jitterDuration:  jitterDuration,
 		skipAutoApprove: *skipAutoApprove,
@@ -260,7 +270,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 		waitForEnrollmentRequest(ctx, params.log, params.agentFolders[i])
 		return
 	}
-	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.formattedLabels)
+	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.perAgentLabels[i])
 }
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
@@ -373,6 +383,7 @@ type createAgentsConfig struct {
 	parsedSourceIPs     []net.IP
 	maxConcurrency      int
 	simulatorLabels     *map[string]string
+	fleetNames          []string
 }
 
 type agentLaunchParams struct {
@@ -380,17 +391,18 @@ type agentLaunchParams struct {
 	agentFolders    []string
 	log             *logrus.Logger
 	serviceClient   *apiClient.ClientWithResponses
-	formattedLabels *map[string]string
+	perAgentLabels  []*map[string]string
 	sem             *semaphore.Weighted
 	jitterDuration  time.Duration
 	skipAutoApprove bool
 }
 
-func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
+func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string, []*map[string]string) {
 	logger := agentCfg.log
 	logger.Infoln("creating agents")
 	agents := make([]*agent.Agent, agentCfg.numDevices)
 	agentsFolders := make([]string, agentCfg.numDevices)
+	perAgentLabels := make([]*map[string]string, agentCfg.numDevices)
 	ex := experimental.NewFeatures()
 	if ex.IsEnabled() && agentCfg.numDevices > 1 {
 		logger.Warnf("Using experimental features with more than one device could cause unexpected issues.")
@@ -421,11 +433,20 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 			logger.Fatalf("Error setting environment variable: %v", err)
 		}
 
-		cfg := agent_config.NewDefault()
+		labels := map[string]string{}
 		if agentCfg.simulatorLabels != nil {
 			for k, v := range *agentCfg.simulatorLabels {
-				cfg.DefaultLabels[k] = v
+				labels[k] = v
 			}
+		}
+		if len(agentCfg.fleetNames) > 0 {
+			labels["fleet"] = agentCfg.fleetNames[i%len(agentCfg.fleetNames)]
+		}
+		perAgentLabels[i] = &labels
+
+		cfg := agent_config.NewDefault()
+		for k, v := range labels {
+			cfg.DefaultLabels[k] = v
 		}
 		cfg.DefaultLabels["alias"] = agentName
 		cfg.ConfigDir = agent_config.DefaultConfigDir
@@ -490,7 +511,7 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 		agents[i] = agentInstance
 		agentsFolders[i] = agentDir
 	}
-	return agents, agentsFolders
+	return agents, agentsFolders, perAgentLabels
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {


### PR DESCRIPTION
## Summary
- Add `--fleet-count` / `--fleet-prefix` to create scale fleets and assign devices round-robin
- Skip default `simulator-disk-monitoring` fleet when scale fleets are enabled

## Stack
Layer 5/7. Depends on devicesim-clean.

## Test plan
- [ ] `bin/devicesimulator --count=10 --fleet-count=2` creates `scale-fleet-00/01` and labels devices evenly

Made with [Cursor](https://cursor.com)