### PR TITLE
NO-ISSUE: add make simulate-devices thin wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ help:
 	@echo "    clean-quadlets:  clean up all systemd services and quadlet files"
 	@echo "    rpm/deb:         generate rpm or debian packages"
 	@echo "    verify-rpm-install: verify package-mode and image-mode RPM install paths (requires podman, bin/rpm)"
+	@echo "    simulate-devices: build and run devicesimulator (pass flags via ARGS=...)"
 	@echo ""
 	@echo "CI/CD Targets:"
 	@echo "    login:           login to container registry (requires REGISTRY_USER env var)"
@@ -205,6 +206,10 @@ build-remote-access: bin
 
 build-devicesimulator: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/devicesimulator
+
+.PHONY: simulate-devices
+simulate-devices: build-devicesimulator
+	bin/devicesimulator $(ARGS)
 
 build-standalone: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-standalone

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -161,7 +162,10 @@ func main() {
 	}
 	cfg, err := client.ParseConfigFile(baseDir)
 	if err != nil {
-		log.Fatalf("could not parse config file: %v", err)
+		if errors.Is(err, os.ErrNotExist) {
+			log.Fatalf("no client config found at %s — run 'flightctl login' first", baseDir)
+		}
+		log.Fatalf("could not parse config file %s: %v", baseDir, err)
 	}
 	if cfg.Organization != "" {
 		log.Infof("using organization %s from client config", cfg.Organization)


### PR DESCRIPTION
## Summary
- Add `make simulate-devices` that builds and runs `bin/devicesimulator $(ARGS)`
- Fail fast with a clear message when client config is missing

## Stack
Layer 7/7 (top). Depends on devicesim-rollout.

## Test plan
- [ ] `make simulate-devices ARGS='--count=1 --log-level=info'`
- [ ] Missing client config prints login hint

Made with [Cursor](https://cursor.com)