### PR TITLE
NO-ISSUE: devicesimulator scale tooling (clean, fleets, rollout)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ help:
 	@echo "    clean-quadlets:  clean up all systemd services and quadlet files"
 	@echo "    rpm/deb:         generate rpm or debian packages"
 	@echo "    verify-rpm-install: verify package-mode and image-mode RPM install paths (requires podman, bin/rpm)"
+	@echo "    simulate-devices: build and run devicesimulator (pass flags via ARGS=...)"
 	@echo ""
 	@echo "CI/CD Targets:"
 	@echo "    login:           login to container registry (requires REGISTRY_USER env var)"
@@ -205,6 +206,10 @@ build-remote-access: bin
 
 build-devicesimulator: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/devicesimulator
+
+.PHONY: simulate-devices
+simulate-devices: build-devicesimulator
+	bin/devicesimulator $(ARGS)
 
 build-standalone: bin
 	$(GOENV) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/flightctl-standalone

--- a/cmd/devicesimulator/clean.go
+++ b/cmd/devicesimulator/clean.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	simulatorCreatedByLabel = "created_by=device-simulator"
+	simulatorCreatedByValue = "device-simulator"
+	cleanupProgressEveryN   = 500
+	cleanupProgressInterval = 5 * time.Second
+	cleanupListLimit        = int32(500)
+)
+
+type cleanupProgress struct {
+	log       *logrus.Logger
+	kind      string
+	deleted   int
+	remaining *int64
+	lastLog   time.Time
+}
+
+func (p *cleanupProgress) maybeLog() {
+	if p.deleted%cleanupProgressEveryN != 0 && time.Since(p.lastLog) < cleanupProgressInterval {
+		return
+	}
+	if p.remaining != nil {
+		p.log.Infof("deleted %d %s so far (%d remaining)", p.deleted, p.kind, *p.remaining)
+	} else {
+		p.log.Infof("deleted %d %s so far", p.deleted, p.kind)
+	}
+	p.lastLog = time.Now()
+}
+
+func cleanSimulatorState(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, dataDir string) error {
+	start := time.Now()
+	log.Infoln("cleaning simulator-created resources")
+
+	localRemoved, err := wipeLocalAgentDirs(log, dataDir)
+	if err != nil {
+		return fmt.Errorf("wiping local agent dirs: %w", err)
+	}
+
+	deviceNames, devicesDeleted, err := deleteLabeledDevices(ctx, log, serviceClient)
+	if err != nil {
+		return fmt.Errorf("deleting simulator devices: %w", err)
+	}
+
+	matchedERs, err := deleteEnrollmentRequestsByName(ctx, log, serviceClient, deviceNames)
+	if err != nil {
+		return fmt.Errorf("deleting enrollment requests by device name: %w", err)
+	}
+
+	pendingERs, err := deletePendingSimulatorEnrollmentRequests(ctx, log, serviceClient)
+	if err != nil {
+		return fmt.Errorf("deleting pending simulator enrollment requests: %w", err)
+	}
+
+	log.Infof("cleanup complete in %s: removed %d local dirs, deleted %d devices, %d matched ERs, %d pending simulator ERs",
+		time.Since(start).Round(time.Millisecond), localRemoved, devicesDeleted, matchedERs, pendingERs)
+	return nil
+}
+
+func wipeLocalAgentDirs(log *logrus.Logger, dataDir string) (int, error) {
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	removed := 0
+	for _, entry := range entries {
+		path := filepath.Join(dataDir, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			return removed, fmt.Errorf("removing %s: %w", path, err)
+		}
+		removed++
+	}
+	log.Infof("removed %d local entries under %s", removed, dataDir)
+	return removed, nil
+}
+
+func deleteLabeledDevices(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses) ([]string, int, error) {
+	selector := simulatorCreatedByLabel
+	limit := cleanupListLimit
+	var continueToken *string
+	names := make([]string, 0)
+	progress := &cleanupProgress{log: log, kind: "devices", lastLog: time.Now()}
+
+	for {
+		resp, err := serviceClient.ListDevicesWithResponse(ctx, &v1beta1.ListDevicesParams{
+			LabelSelector: &selector,
+			Limit:         &limit,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return nil, progress.deleted, err
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return nil, progress.deleted, fmt.Errorf("list devices: status %d", resp.StatusCode())
+		}
+
+		progress.remaining = resp.JSON200.Metadata.RemainingItemCount
+		for _, device := range resp.JSON200.Items {
+			if device.Metadata.Name == nil {
+				continue
+			}
+			name := *device.Metadata.Name
+			delResp, err := serviceClient.DeleteDeviceWithResponse(ctx, name)
+			if err != nil {
+				return names, progress.deleted, fmt.Errorf("delete device %s: %w", name, err)
+			}
+			code := delResp.StatusCode()
+			if code != http.StatusOK && code != http.StatusNoContent && code != http.StatusNotFound {
+				return names, progress.deleted, fmt.Errorf("delete device %s: status %d", name, code)
+			}
+			if code != http.StatusNotFound {
+				names = append(names, name)
+				progress.deleted++
+				progress.maybeLog()
+			}
+		}
+
+		if resp.JSON200.Metadata.Continue == nil || *resp.JSON200.Metadata.Continue == "" {
+			break
+		}
+		continueToken = resp.JSON200.Metadata.Continue
+	}
+	return names, progress.deleted, nil
+}
+
+func deleteEnrollmentRequestsByName(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, names []string) (int, error) {
+	progress := &cleanupProgress{log: log, kind: "matched enrollment requests", lastLog: time.Now()}
+	for _, name := range names {
+		delResp, err := serviceClient.DeleteEnrollmentRequestWithResponse(ctx, name)
+		if err != nil {
+			log.Warnf("delete enrollment request %s: %v", name, err)
+			continue
+		}
+		code := delResp.StatusCode()
+		if code == http.StatusNotFound {
+			continue
+		}
+		if code != http.StatusOK && code != http.StatusNoContent {
+			log.Warnf("delete enrollment request %s: status %d", name, code)
+			continue
+		}
+		progress.deleted++
+		progress.maybeLog()
+	}
+	return progress.deleted, nil
+}
+
+func deletePendingSimulatorEnrollmentRequests(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses) (int, error) {
+	fieldSelector := "status.approval.approved!=true"
+	limit := cleanupListLimit
+	var continueToken *string
+	progress := &cleanupProgress{log: log, kind: "pending simulator enrollment requests", lastLog: time.Now()}
+
+	for {
+		resp, err := serviceClient.ListEnrollmentRequestsWithResponse(ctx, &v1beta1.ListEnrollmentRequestsParams{
+			FieldSelector: &fieldSelector,
+			Limit:         &limit,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return progress.deleted, err
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return progress.deleted, fmt.Errorf("list enrollment requests: status %d", resp.StatusCode())
+		}
+
+		progress.remaining = resp.JSON200.Metadata.RemainingItemCount
+		for _, er := range resp.JSON200.Items {
+			if er.Metadata.Name == nil || er.Spec.Labels == nil {
+				continue
+			}
+			if (*er.Spec.Labels)["created_by"] != simulatorCreatedByValue {
+				continue
+			}
+			name := *er.Metadata.Name
+			delResp, err := serviceClient.DeleteEnrollmentRequestWithResponse(ctx, name)
+			if err != nil {
+				return progress.deleted, fmt.Errorf("delete enrollment request %s: %w", name, err)
+			}
+			code := delResp.StatusCode()
+			if code == http.StatusNotFound {
+				continue
+			}
+			if code != http.StatusOK && code != http.StatusNoContent {
+				return progress.deleted, fmt.Errorf("delete enrollment request %s: status %d", name, code)
+			}
+			progress.deleted++
+			progress.maybeLog()
+		}
+
+		if resp.JSON200.Metadata.Continue == nil || *resp.JSON200.Metadata.Continue == "" {
+			break
+		}
+		continueToken = resp.JSON200.Metadata.Continue
+	}
+	return progress.deleted, nil
+}

--- a/cmd/devicesimulator/fleets.go
+++ b/cmd/devicesimulator/fleets.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/sirupsen/logrus"
+)
+
+func scaleFleetNames(prefix string, count int) []string {
+	names := make([]string, count)
+	for i := 0; i < count; i++ {
+		names[i] = fmt.Sprintf("%s-%02d", prefix, i)
+	}
+	return names
+}
+
+func createScaleFleets(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, prefix string, count int) ([]string, error) {
+	names := scaleFleetNames(prefix, count)
+	for _, name := range names {
+		response, err := serviceClient.GetFleetWithResponse(ctx, name, &v1beta1.GetFleetParams{})
+		if err == nil && response.HTTPResponse != nil && response.HTTPResponse.StatusCode == http.StatusOK {
+			log.Infof("Fleet %s already exists, skipping creation", name)
+			continue
+		}
+
+		fleet, err := newScaleFleet(name)
+		if err != nil {
+			return nil, fmt.Errorf("building fleet %s: %w", name, err)
+		}
+		fleetJSON, err := json.Marshal(fleet)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling fleet %s: %w", name, err)
+		}
+		createResponse, err := serviceClient.ReplaceFleetWithBodyWithResponse(ctx, name, "application/json", bytes.NewReader(fleetJSON))
+		if err != nil {
+			return nil, fmt.Errorf("creating fleet %s: %w", name, err)
+		}
+		if createResponse.StatusCode() < http.StatusOK || createResponse.StatusCode() >= http.StatusMultipleChoices {
+			return nil, fmt.Errorf("creating fleet %s: status %d, body: %s", name, createResponse.StatusCode(), string(createResponse.Body))
+		}
+		log.Infof("Successfully created fleet: %s", name)
+	}
+	return names, nil
+}
+
+func newScaleFleet(name string) (*v1beta1.Fleet, error) {
+	mode := 0644
+	content := fmt.Sprintf("This system is managed by flightctl (fleet %s).", name)
+	var configItem v1beta1.ConfigProviderSpec
+	if err := configItem.FromInlineConfigProviderSpec(v1beta1.InlineConfigProviderSpec{
+		Name: "motd-update",
+		Inline: []v1beta1.FileSpec{
+			{
+				Path:    "/etc/motd",
+				Content: content,
+				Mode:    &mode,
+			},
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	matchLabels := map[string]string{"fleet": name}
+	templateLabels := map[string]string{"fleet": name}
+	return &v1beta1.Fleet{
+		ApiVersion: v1beta1.ApiVersion("flightctl.io/v1beta1"),
+		Kind:       v1beta1.FleetKind,
+		Metadata: v1beta1.ObjectMeta{
+			Name: &name,
+		},
+		Spec: v1beta1.FleetSpec{
+			Selector: &v1beta1.LabelSelector{
+				MatchLabels: &matchLabels,
+			},
+			Template: struct {
+				Metadata *v1beta1.ObjectMeta `json:"metadata,omitempty"`
+				Spec     v1beta1.DeviceSpec  `json:"spec"`
+			}{
+				Metadata: &v1beta1.ObjectMeta{
+					Labels: &templateLabels,
+				},
+				Spec: v1beta1.DeviceSpec{
+					Config: &[]v1beta1.ConfigProviderSpec{configItem},
+				},
+			},
+		},
+	}, nil
+}

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"math/rand/v2"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -20,7 +19,6 @@ import (
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	"github.com/flightctl/flightctl/internal/agent"
 	agent_config "github.com/flightctl/flightctl/internal/agent/config"
-	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
 	apiClient "github.com/flightctl/flightctl/internal/api/client"
 	"github.com/flightctl/flightctl/internal/client"
 	baseclient "github.com/flightctl/flightctl/internal/client"
@@ -248,23 +246,15 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 }
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
-		log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
-		bannerFileData, err := readBannerFile(agentDir)
-		if err != nil {
-			return false, nil
+	log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, 5*time.Second, 5*time.Minute)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Errorf("Error waiting for enrollment request: %v", err)
 		}
-		enrollmentID := testutil.GetEnrollmentIdFromText(bannerFileData)
-		if enrollmentID == "" {
-			log.Warnf("No enrollment id found in banner file %s", bannerFileData)
-			return false, nil
-		}
-		log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
-		return true, nil
-	})
-	if err != nil && ctx.Err() == nil {
-		log.Errorf("Error waiting for enrollment request: %v", err)
+		return
 	}
+	log.Infof("Enrollment request visible for agent %s (id: %s)", filepath.Base(agentDir), enrollmentID)
 }
 
 func reportVersion(versionFormat *string) error {
@@ -471,80 +461,27 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 			enrollmentTransport,
 		)
 
-		if err := cfg.Complete(); err != nil {
+		cfg.LogLevel = agentCfg.agentConfigTemplate.LogLevel
+		agentInstance, err := testutil.NewSimulatedAgent(cfg, agentName)
+		if err != nil {
 			logger.Fatalf("agent config %d: %v", i, err)
 		}
-		if err := cfg.Validate(); err != nil {
-			logger.Fatalf("agent config %d: %v", i, err)
-		}
-
-		logWithPrefix := flightlog.NewPrefixLogger(agentName)
-		logWithPrefix.Level(agentCfg.agentConfigTemplate.LogLevel)
-		agents[i] = agent.New(logWithPrefix, cfg, "")
+		agents[i] = agentInstance
 		agentsFolders[i] = agentDir
 	}
 	return agents, agentsFolders
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
-	enrollmentId := ""
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
-		log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
-		if enrollmentId == "" {
-			bannerFileData, err := readBannerFile(agentDir)
-			if err != nil {
-				log.Warnf("Error reading banner file: %v", err)
-				return false, nil
-			}
-			enrollmentId = testutil.GetEnrollmentIdFromText(bannerFileData)
-			if enrollmentId == "" {
-				log.Warnf("No enrollment id found in banner file %s", bannerFileData)
-				return false, nil
-			}
-		}
-		// timeout after 30s and retry
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-		resp, err := serviceClient.ApproveEnrollmentRequestWithResponse(
-			ctx,
-			enrollmentId,
-			v1beta1.EnrollmentRequestApproval{
-				Approved: true,
-				Labels:   labels,
-			})
-		if err != nil {
-			log.Errorf("Error approving device %s enrollment: %v", enrollmentId, err)
-			return false, nil
-		}
-		responseCode := resp.StatusCode()
-		if responseCode == http.StatusNotFound {
-			// no error, but don't log this. There could be a race condition in posting vs approving and is not exceptional
-			return false, nil
-		}
-		if responseCode < http.StatusOK || responseCode >= http.StatusMultipleChoices {
-			log.Warnf("Failed approving device %s enrollment: %d", enrollmentId, responseCode)
-			return false, nil
-		}
-		log.Infof("Approved device enrollment %s", enrollmentId)
-		return true, nil
-	})
-	if err != nil && ctx.Err() == nil {
-		log.Errorf("Error approving device enrollment: %v", err)
-	}
-}
-
-func readBannerFile(agentDir string) (string, error) {
-	var data []byte
-	var err error
-	bannerFile := filepath.Join(agentDir, lifecycle.BannerFile)
-	if _, err = os.Stat(bannerFile); err != nil {
-		return "", err
-	}
-	data, err = os.ReadFile(bannerFile)
+	log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
+	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, 5*time.Second, 5*time.Minute)
 	if err != nil {
-		return "", err
+		if ctx.Err() == nil {
+			log.Errorf("Error approving device enrollment: %v", err)
+		}
+		return
 	}
-	return string(data), nil
+	log.Infof("Approved device enrollment %s", enrollmentID)
 }
 
 func copyFile(from, to string) error {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -76,6 +76,8 @@ func main() {
 	maxConcurrency := pflag.Int("max-concurrency", 100, "maximum number of concurrent agent operations")
 	agentStartupJitter := pflag.Duration("agent-startup-jitter", -1*time.Second, "maximum random delay when starting agents (negative = use status-update-interval, 0 = no jitter, positive = custom duration)")
 	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
+	clean := pflag.Bool("clean", false, "wipe local simulator state and delete simulator-created devices/enrollment requests before starting")
+	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -162,12 +164,23 @@ func main() {
 		log.Fatalf("Error creating service client: %v", err)
 	}
 
-	log.Infoln("creating agents")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	serviceClient.Start(ctx)
 	defer serviceClient.Stop()
+
+	if *clean || *cleanOnly {
+		if err := cleanSimulatorState(ctx, log, serviceClient.ClientWithResponses, *dataDir); err != nil {
+			log.Fatalf("cleanup failed: %v", err)
+		}
+		if *cleanOnly {
+			log.Infoln("clean-only complete, exiting")
+			return
+		}
+	}
+
+	log.Infoln("creating agents")
 
 	// Create simulator fleet configuration
 	if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
@@ -521,7 +534,7 @@ func formatLabels(lableArgs *[]string) *map[string]string {
 		formattedLabels = util.LabelArrayToMap(*lableArgs)
 	}
 
-	formattedLabels["created_by"] = "device-simulator"
+	formattedLabels["created_by"] = simulatorCreatedByValue
 	return &formattedLabels
 }
 

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -150,6 +150,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not parse config file: %v", err)
 	}
+	if cfg.Organization != "" {
+		log.Infof("using organization %s from client config", cfg.Organization)
+	} else {
+		log.Infoln("no organization set in client config")
+	}
 	// allow many idle conns to prevent tearing down connections we may need again
 	cfg.AddHTTPOptions(client.WithMaxIdleConnsPerHost(*maxConcurrency))
 	serviceClient, err := client.NewFromConfig(cfg, baseDir)
@@ -248,6 +253,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
 	log.Infof("Waiting for enrollment request for agent %s", filepath.Base(agentDir))
 	enrollmentID, err := testutil.WaitForEnrollmentID(ctx, agentDir, 5*time.Second, 5*time.Minute)
+	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
 			log.Errorf("Error waiting for enrollment request: %v", err)
@@ -477,6 +483,7 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {
 	log.Infof("Approving device enrollment if exists for agent %s", filepath.Base(agentDir))
 	enrollmentID, err := testutil.ApproveEnrollment(ctx, serviceClient, agentDir, labels, 5*time.Second, 5*time.Minute)
+	recordEnrollmentOutcome(ctx, err)
 	if err != nil {
 		if ctx.Err() == nil {
 			log.Errorf("Error approving device enrollment: %v", err)

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -383,22 +383,24 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 		agentName := fmt.Sprintf("device-%05d", agentCfg.initialDeviceIndex+i)
 		certDir := filepath.Join(agentCfg.agentConfigTemplate.ConfigDir, "certs")
 		agentDir := filepath.Join(agentCfg.agentConfigTemplate.DataDir, agentName)
-		// Cleanup if exists and initialize the agent's expected
-		os.RemoveAll(agentDir)
-		if err := os.MkdirAll(filepath.Join(agentDir, agent_config.DefaultConfigDir), 0700); err != nil {
-			logger.Fatalf("Error creating directory: %v", err)
+
+		_, err := os.Stat(agentDir)
+		resuming := err == nil
+		if resuming {
+			logger.Infof("resuming existing state for agent %s", agentName)
+		} else {
+			if err := os.MkdirAll(filepath.Join(agentDir, agent_config.DefaultConfigDir), 0700); err != nil {
+				logger.Fatalf("Error creating directory: %v", err)
+			}
+			if ex.IsEnabled() {
+				setupTPMLinks(agentDir, logger)
+			}
+			copyAgentFiles(logger, certDir, agentDir)
 		}
 
-		if ex.IsEnabled() {
-			setupTPMLinks(agentDir, logger)
-		}
-
-		err := os.Setenv(client.TestRootDirEnvKey, agentDir)
-		if err != nil {
+		if err := os.Setenv(client.TestRootDirEnvKey, agentDir); err != nil {
 			logger.Fatalf("Error setting environment variable: %v", err)
 		}
-
-		copyAgentFiles(logger, certDir, agentDir)
 
 		cfg := agent_config.NewDefault()
 		if agentCfg.simulatorLabels != nil {

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -80,6 +80,9 @@ func main() {
 	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
 	fleetCount := pflag.Int("fleet-count", 0, "number of scale fleets to create and distribute devices across (0 disables)")
 	fleetPrefix := pflag.String("fleet-prefix", "scale-fleet", "prefix for scale fleet names (<prefix>-NN)")
+	rollout := pflag.Bool("rollout", false, "standalone mode: update fleet templates and measure rollout convergence, then exit")
+	rolloutTemplate := pflag.String("rollout-template", "", "path to a Fleet YAML whose .spec.template is applied during --rollout")
+	rolloutTimeout := pflag.Duration("rollout-timeout", 15*time.Minute, "how long --rollout waits for devices to become UpToDate")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -115,6 +118,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *rollout && (*clean || *cleanOnly) {
+		log.Fatalf("--rollout is mutually exclusive with --clean/--clean-only")
+	}
+	if *rollout && *rolloutTemplate == "" {
+		log.Fatalf("--rollout requires --rollout-template")
+	}
+	if *rollout && *fleetCount <= 0 {
+		log.Fatalf("--rollout requires --fleet-count > 0")
+	}
+
 	// Disable console banner for all simulated agents
 	if err := os.Setenv("FLIGHTCTL_DISABLE_CONSOLE_BANNER", "true"); err != nil {
 		log.Fatalf("Error setting banner disable environment variable: %v", err)
@@ -135,10 +148,6 @@ func main() {
 	pflag.CommandLine.VisitAll(func(flg *pflag.Flag) {
 		log.Infof("  %s=%s", flg.Name, flg.Value)
 	})
-
-	formattedLables := formatLabels(labels)
-
-	agentConfigTemplate := createAgentConfigTemplate(*dataDir, *configFile, *logLevel)
 
 	log.Infoln("starting device simulator")
 	defer log.Infoln("device simulator stopped")
@@ -181,6 +190,16 @@ func main() {
 			return
 		}
 	}
+
+	if *rollout {
+		if err := runRollout(ctx, log, serviceClient.ClientWithResponses, *fleetPrefix, *fleetCount, *rolloutTemplate, *rolloutTimeout); err != nil {
+			log.Fatalf("rollout failed: %v", err)
+		}
+		return
+	}
+
+	formattedLables := formatLabels(labels)
+	agentConfigTemplate := createAgentConfigTemplate(*dataDir, *configFile, *logLevel)
 
 	log.Infoln("creating agents")
 

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -161,7 +162,10 @@ func main() {
 	}
 	cfg, err := client.ParseConfigFile(baseDir)
 	if err != nil {
-		log.Fatalf("could not parse config file: %v", err)
+		if errors.Is(err, os.ErrNotExist) {
+			log.Fatalf("no client config found at %s — run 'flightctl login' first", baseDir)
+		}
+		log.Fatalf("could not parse config file %s: %v", baseDir, err)
 	}
 	if cfg.Organization != "" {
 		log.Infof("using organization %s from client config", cfg.Organization)

--- a/cmd/devicesimulator/main.go
+++ b/cmd/devicesimulator/main.go
@@ -78,6 +78,8 @@ func main() {
 	skipAutoApprove := pflag.Bool("skip-auto-approve", false, "do not auto-approve enrollment requests (agents wait for manual approval)")
 	clean := pflag.Bool("clean", false, "wipe local simulator state and delete simulator-created devices/enrollment requests before starting")
 	cleanOnly := pflag.Bool("clean-only", false, "wipe local simulator state and delete simulator-created devices/enrollment requests, then exit")
+	fleetCount := pflag.Int("fleet-count", 0, "number of scale fleets to create and distribute devices across (0 disables)")
+	fleetPrefix := pflag.String("fleet-prefix", "scale-fleet", "prefix for scale fleet names (<prefix>-NN)")
 	versionFormat := pflag.StringP("output", "o", "", fmt.Sprintf("Output format. One of: (%s). Default: text format", strings.Join(outputTypes, ", ")))
 	logLevel := pflag.StringP("log-level", "v", "debug", "logger verbosity level (one of \"fatal\", \"error\", \"warn\", \"warning\", \"info\", \"debug\")")
 
@@ -182,12 +184,19 @@ func main() {
 
 	log.Infoln("creating agents")
 
-	// Create simulator fleet configuration
-	if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
+	var fleetNames []string
+	if *fleetCount > 0 {
+		log.Infof("skipping default simulator-disk-monitoring fleet because --fleet-count=%d", *fleetCount)
+		var err error
+		fleetNames, err = createScaleFleets(ctx, log, serviceClient.ClientWithResponses, *fleetPrefix, *fleetCount)
+		if err != nil {
+			log.Fatalf("Failed to create scale fleets: %v", err)
+		}
+	} else if err := createSimulatorFleet(ctx, serviceClient.ClientWithResponses, log); err != nil {
 		log.Warnf("Failed to create simulator fleet: %v", err)
 	}
 
-	agents, agentsFolders := createAgents(createAgentsConfig{
+	agents, agentsFolders, perAgentLabels := createAgents(createAgentsConfig{
 		log:                 log,
 		numDevices:          *numDevices,
 		initialDeviceIndex:  *initialDeviceIndex,
@@ -195,6 +204,7 @@ func main() {
 		parsedSourceIPs:     parsedSourceIPs,
 		maxConcurrency:      *maxConcurrency,
 		simulatorLabels:     formattedLables,
+		fleetNames:          fleetNames,
 	})
 
 	sigShutdown := make(chan os.Signal, 1)
@@ -221,7 +231,7 @@ func main() {
 		agentFolders:    agentsFolders,
 		log:             log,
 		serviceClient:   serviceClient.ClientWithResponses,
-		formattedLabels: formattedLables,
+		perAgentLabels:  perAgentLabels,
 		sem:             sem,
 		jitterDuration:  jitterDuration,
 		skipAutoApprove: *skipAutoApprove,
@@ -260,7 +270,7 @@ func launchAgent(ctx context.Context, i int, params agentLaunchParams) {
 		waitForEnrollmentRequest(ctx, params.log, params.agentFolders[i])
 		return
 	}
-	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.formattedLabels)
+	approveAgent(ctx, params.log, params.serviceClient, params.agentFolders[i], params.perAgentLabels[i])
 }
 
 func waitForEnrollmentRequest(ctx context.Context, log *logrus.Logger, agentDir string) {
@@ -373,6 +383,7 @@ type createAgentsConfig struct {
 	parsedSourceIPs     []net.IP
 	maxConcurrency      int
 	simulatorLabels     *map[string]string
+	fleetNames          []string
 }
 
 type agentLaunchParams struct {
@@ -380,17 +391,18 @@ type agentLaunchParams struct {
 	agentFolders    []string
 	log             *logrus.Logger
 	serviceClient   *apiClient.ClientWithResponses
-	formattedLabels *map[string]string
+	perAgentLabels  []*map[string]string
 	sem             *semaphore.Weighted
 	jitterDuration  time.Duration
 	skipAutoApprove bool
 }
 
-func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
+func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string, []*map[string]string) {
 	logger := agentCfg.log
 	logger.Infoln("creating agents")
 	agents := make([]*agent.Agent, agentCfg.numDevices)
 	agentsFolders := make([]string, agentCfg.numDevices)
+	perAgentLabels := make([]*map[string]string, agentCfg.numDevices)
 	ex := experimental.NewFeatures()
 	if ex.IsEnabled() && agentCfg.numDevices > 1 {
 		logger.Warnf("Using experimental features with more than one device could cause unexpected issues.")
@@ -421,11 +433,20 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 			logger.Fatalf("Error setting environment variable: %v", err)
 		}
 
-		cfg := agent_config.NewDefault()
+		labels := map[string]string{}
 		if agentCfg.simulatorLabels != nil {
 			for k, v := range *agentCfg.simulatorLabels {
-				cfg.DefaultLabels[k] = v
+				labels[k] = v
 			}
+		}
+		if len(agentCfg.fleetNames) > 0 {
+			labels["fleet"] = agentCfg.fleetNames[i%len(agentCfg.fleetNames)]
+		}
+		perAgentLabels[i] = &labels
+
+		cfg := agent_config.NewDefault()
+		for k, v := range labels {
+			cfg.DefaultLabels[k] = v
 		}
 		cfg.DefaultLabels["alias"] = agentName
 		cfg.ConfigDir = agent_config.DefaultConfigDir
@@ -490,7 +511,7 @@ func createAgents(agentCfg createAgentsConfig) ([]*agent.Agent, []string) {
 		agents[i] = agentInstance
 		agentsFolders[i] = agentDir
 	}
-	return agents, agentsFolders
+	return agents, agentsFolders, perAgentLabels
 }
 
 func approveAgent(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string) {

--- a/cmd/devicesimulator/prometheus.go
+++ b/cmd/devicesimulator/prometheus.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
 
@@ -51,6 +56,15 @@ var (
 		},
 		[]string{"operation", "result"},
 	)
+	enrollmentOutcomes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "enrollment_outcomes_total",
+			Help:      "Total enrollment wait/approve outcomes, partitioned by result",
+		},
+		[]string{"result"},
+	)
 )
 
 func setupMetricsEndpoint(metricsAddress string) {
@@ -66,6 +80,7 @@ func setupMetricsEndpoint(metricsAddress string) {
 	prometheus.MustRegister(apiRequests)
 	prometheus.MustRegister(apiErrors)
 	prometheus.MustRegister(apiRequestDurations)
+	prometheus.MustRegister(enrollmentOutcomes)
 }
 
 func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {
@@ -80,6 +95,48 @@ func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {
 }
 
 func reasonFromAPIError(err error) string {
-	errorType := "unknown"
-	return errorType
+	if err == nil {
+		return "unknown"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		msg := opErr.Error()
+		if strings.Contains(msg, "cannot assign requested address") {
+			return "bind"
+		}
+		if opErr.Op == "dial" {
+			return "dial"
+		}
+		return "connection"
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "cannot assign requested address") {
+		return "bind"
+	}
+	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "connection reset") {
+		return "connection"
+	}
+	if strings.Contains(msg, "dial ") {
+		return "dial"
+	}
+	return "unknown"
+}
+
+func recordEnrollmentOutcome(ctx context.Context, err error) {
+	switch {
+	case err == nil:
+		enrollmentOutcomes.WithLabelValues("approved").Inc()
+	case ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled):
+		enrollmentOutcomes.WithLabelValues("cancelled").Inc()
+	case wait.Interrupted(err) || errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded):
+		enrollmentOutcomes.WithLabelValues("timeout").Inc()
+	default:
+		enrollmentOutcomes.WithLabelValues("error").Inc()
+	}
 }

--- a/cmd/devicesimulator/prometheus.go
+++ b/cmd/devicesimulator/prometheus.go
@@ -65,6 +65,15 @@ var (
 		},
 		[]string{"result"},
 	)
+	rolloutDevicesByStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "rollout_devices_by_status",
+			Help:      "Current device counts during rollout, partitioned by fleet and updated status",
+		},
+		[]string{"fleet", "status"},
+	)
 )
 
 func setupMetricsEndpoint(metricsAddress string) {
@@ -81,6 +90,7 @@ func setupMetricsEndpoint(metricsAddress string) {
 	prometheus.MustRegister(apiErrors)
 	prometheus.MustRegister(apiRequestDurations)
 	prometheus.MustRegister(enrollmentOutcomes)
+	prometheus.MustRegister(rolloutDevicesByStatus)
 }
 
 func rpcMetricsCallback(operation string, duractionSeconds float64, err error) {

--- a/cmd/devicesimulator/rollout.go
+++ b/cmd/devicesimulator/rollout.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+)
+
+// fleetTemplate aliases the anonymous Template struct on FleetSpec.
+type fleetTemplate = struct {
+	Metadata *v1beta1.ObjectMeta `json:"metadata,omitempty"`
+	Spec     v1beta1.DeviceSpec  `json:"spec"`
+}
+
+func runRollout(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, fleetPrefix string, fleetCount int, templatePath string, timeout time.Duration) error {
+	if fleetCount <= 0 {
+		return fmt.Errorf("--rollout requires --fleet-count > 0")
+	}
+	if templatePath == "" {
+		return fmt.Errorf("--rollout requires --rollout-template")
+	}
+
+	template, err := loadFleetTemplate(templatePath)
+	if err != nil {
+		return err
+	}
+
+	fleetNames := scaleFleetNames(fleetPrefix, fleetCount)
+	for _, name := range fleetNames {
+		if err := applyFleetTemplate(ctx, log, serviceClient, name, template); err != nil {
+			return err
+		}
+	}
+
+	log.Infof("waiting up to %s for rollout convergence across %d fleets", timeout, len(fleetNames))
+	log.Infoln("note: devices stuck at OutOfDate may reproduce the known non-atomic fleet rollout render race")
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(cleanupProgressInterval)
+	defer ticker.Stop()
+
+	for {
+		allUpToDate, summaries, err := pollRolloutStatus(ctx, serviceClient, fleetNames)
+		if err != nil {
+			return err
+		}
+		for _, summary := range summaries {
+			log.Infof("fleet %s: upToDate=%d updating=%d outOfDate=%d unknown=%d total=%d",
+				summary.name, summary.upToDate, summary.updating, summary.outOfDate, summary.unknown, summary.total)
+		}
+		if allUpToDate {
+			log.Infoln("rollout complete: all devices report UpToDate")
+			return nil
+		}
+		if time.Now().After(deadline) {
+			log.Warnln("rollout timed out before full convergence")
+			for _, summary := range summaries {
+				log.Warnf("final fleet %s: upToDate=%d updating=%d outOfDate=%d unknown=%d total=%d",
+					summary.name, summary.upToDate, summary.updating, summary.outOfDate, summary.unknown, summary.total)
+			}
+			return fmt.Errorf("rollout timed out after %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func loadFleetTemplate(path string) (fleetTemplate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fleetTemplate{}, fmt.Errorf("reading rollout template %s: %w", path, err)
+	}
+	var fleet v1beta1.Fleet
+	if err := yaml.Unmarshal(data, &fleet); err != nil {
+		return fleetTemplate{}, fmt.Errorf("unmarshaling rollout template: %w", err)
+	}
+	return fleet.Spec.Template, nil
+}
+
+func applyFleetTemplate(ctx context.Context, log *logrus.Logger, serviceClient *apiClient.ClientWithResponses, name string, template fleetTemplate) error {
+	getResp, err := serviceClient.GetFleetWithResponse(ctx, name, &v1beta1.GetFleetParams{})
+	if err != nil {
+		return fmt.Errorf("get fleet %s: %w", name, err)
+	}
+	if getResp.StatusCode() != http.StatusOK || getResp.JSON200 == nil {
+		return fmt.Errorf("get fleet %s: status %d", name, getResp.StatusCode())
+	}
+	fleet := *getResp.JSON200
+	fleet.Spec.Template = template
+	replaceResp, err := serviceClient.ReplaceFleetWithResponse(ctx, name, fleet)
+	if err != nil {
+		return fmt.Errorf("replace fleet %s: %w", name, err)
+	}
+	if replaceResp.StatusCode() < http.StatusOK || replaceResp.StatusCode() >= http.StatusMultipleChoices {
+		return fmt.Errorf("replace fleet %s: status %d, body: %s", name, replaceResp.StatusCode(), string(replaceResp.Body))
+	}
+	log.Infof("updated fleet template for %s", name)
+	return nil
+}
+
+type fleetRolloutSummary struct {
+	name      string
+	upToDate  int
+	updating  int
+	outOfDate int
+	unknown   int
+	total     int
+}
+
+func pollRolloutStatus(ctx context.Context, serviceClient *apiClient.ClientWithResponses, fleetNames []string) (bool, []fleetRolloutSummary, error) {
+	summaries := make([]fleetRolloutSummary, 0, len(fleetNames))
+	allUpToDate := true
+	for _, name := range fleetNames {
+		summary, err := tallyFleetDevices(ctx, serviceClient, name)
+		if err != nil {
+			return false, nil, err
+		}
+		summaries = append(summaries, summary)
+		updateRolloutMetrics(summary)
+		if summary.total == 0 || summary.upToDate != summary.total {
+			allUpToDate = false
+		}
+	}
+	return allUpToDate, summaries, nil
+}
+
+func tallyFleetDevices(ctx context.Context, serviceClient *apiClient.ClientWithResponses, fleetName string) (fleetRolloutSummary, error) {
+	summary := fleetRolloutSummary{name: fleetName}
+	selector := fmt.Sprintf("fleet=%s", fleetName)
+	limit := cleanupListLimit
+	var continueToken *string
+
+	for {
+		resp, err := serviceClient.ListDevicesWithResponse(ctx, &v1beta1.ListDevicesParams{
+			LabelSelector: &selector,
+			Limit:         &limit,
+			Continue:      continueToken,
+		})
+		if err != nil {
+			return summary, fmt.Errorf("list devices for fleet %s: %w", fleetName, err)
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return summary, fmt.Errorf("list devices for fleet %s: status %d", fleetName, resp.StatusCode())
+		}
+		for _, device := range resp.JSON200.Items {
+			summary.total++
+			if device.Status == nil {
+				summary.unknown++
+				continue
+			}
+			switch device.Status.Updated.Status {
+			case v1beta1.DeviceUpdatedStatusUpToDate:
+				summary.upToDate++
+			case v1beta1.DeviceUpdatedStatusUpdating:
+				summary.updating++
+			case v1beta1.DeviceUpdatedStatusOutOfDate:
+				summary.outOfDate++
+			default:
+				summary.unknown++
+			}
+		}
+		if resp.JSON200.Metadata.Continue == nil || *resp.JSON200.Metadata.Continue == "" {
+			break
+		}
+		continueToken = resp.JSON200.Metadata.Continue
+	}
+	return summary, nil
+}
+
+func updateRolloutMetrics(summary fleetRolloutSummary) {
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusUpToDate)).Set(float64(summary.upToDate))
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusUpdating)).Set(float64(summary.updating))
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusOutOfDate)).Set(float64(summary.outOfDate))
+	rolloutDevicesByStatus.WithLabelValues(summary.name, string(v1beta1.DeviceUpdatedStatusUnknown)).Set(float64(summary.unknown))
+}

--- a/test/harness/test_harness.go
+++ b/test/harness/test_harness.go
@@ -452,11 +452,13 @@ func (h *TestHarness) StopAgent() {
 }
 
 func (h *TestHarness) StartAgent() {
-	agentLog := log.NewPrefixLogger("")
-
 	// Use SafeExecuter in tests to prevent dangerous commands like systemctl reboot
 	safeExec := testutil.NewDefaultSafeExecuter()
-	agentInstance := agent.New(agentLog, h.agentConfig, "", agent.WithExecuter(safeExec))
+	agentInstance, err := testutil.NewSimulatedAgent(h.agentConfig, "", agent.WithExecuter(safeExec))
+	if err != nil {
+		h.goRoutineErrorHandler(fmt.Errorf("error constructing agent: %w", err))
+		return
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	h.agentFinished = make(chan struct{})

--- a/test/util/simagent.go
+++ b/test/util/simagent.go
@@ -1,0 +1,105 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent"
+	agent_config "github.com/flightctl/flightctl/internal/agent/config"
+	"github.com/flightctl/flightctl/internal/agent/device/lifecycle"
+	apiClient "github.com/flightctl/flightctl/internal/api/client"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// NewSimulatedAgent finalizes cfg (Complete + Validate) and constructs the corresponding agent.Agent
+// with a prefixed logger. This consolidates the setup sequence previously duplicated between
+// devicesimulator and integration test harnesses.
+func NewSimulatedAgent(cfg *agent_config.Config, name string, opts ...agent.AgentOption) (*agent.Agent, error) {
+	if err := cfg.Complete(); err != nil {
+		return nil, fmt.Errorf("completing agent config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validating agent config: %w", err)
+	}
+	logWithPrefix := flightlog.NewPrefixLogger(name)
+	if cfg.LogLevel != "" {
+		logWithPrefix.Level(cfg.LogLevel)
+	}
+	return agent.New(logWithPrefix, cfg, "", opts...), nil
+}
+
+// ReadBannerFile reads the enrollment banner file written by the agent's lifecycle manager under agentDir.
+func ReadBannerFile(agentDir string) (string, error) {
+	bannerFile := filepath.Join(agentDir, lifecycle.BannerFile)
+	if _, err := os.Stat(bannerFile); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(bannerFile)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WaitForEnrollmentID polls agentDir's banner file until an enrollment ID appears, the context is
+// cancelled, or timeout elapses. Returns the discovered enrollment ID (empty if never found) and
+// the poll error, if any.
+func WaitForEnrollmentID(ctx context.Context, agentDir string, pollInterval, timeout time.Duration) (string, error) {
+	enrollmentID := ""
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+		bannerFileData, err := ReadBannerFile(agentDir)
+		if err != nil {
+			return false, nil
+		}
+		enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+		return enrollmentID != "", nil
+	})
+	return enrollmentID, err
+}
+
+// ApproveEnrollment polls agentDir's banner file for the enrollment ID and repeatedly attempts to
+// approve it via serviceClient until it succeeds, the context is cancelled, or timeout elapses.
+// Returns the discovered enrollment ID (empty if never found) and a terminal error (nil on success).
+func ApproveEnrollment(ctx context.Context, serviceClient *apiClient.ClientWithResponses, agentDir string, labels *map[string]string, pollInterval, timeout time.Duration) (string, error) {
+	enrollmentID := ""
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
+		if enrollmentID == "" {
+			bannerFileData, err := ReadBannerFile(agentDir)
+			if err != nil {
+				return false, nil
+			}
+			enrollmentID = GetEnrollmentIdFromText(bannerFileData)
+			if enrollmentID == "" {
+				return false, nil
+			}
+		}
+		approveCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		resp, err := serviceClient.ApproveEnrollmentRequestWithResponse(
+			approveCtx,
+			enrollmentID,
+			v1beta1.EnrollmentRequestApproval{
+				Approved: true,
+				Labels:   labels,
+			})
+		if err != nil {
+			return false, nil
+		}
+		code := resp.StatusCode()
+		if code == http.StatusNotFound {
+			// no error, but don't treat as exceptional: there can be a race between posting and approving
+			return false, nil
+		}
+		if code < http.StatusOK || code >= http.StatusMultipleChoices {
+			return false, nil
+		}
+		return true, nil
+	})
+	return enrollmentID, err
+}


### PR DESCRIPTION
## Summary
- Extract shared simulated-agent helpers into `test/util` and resume device identity across reruns
- Add enrollment outcome metrics, RPC error classification, and org logging
- Add `--clean`/`--clean-only`, `--fleet-count` distribution, standalone `--rollout`, and `make simulate-devices`

Stacked on `EDM-4335-status-update-optimizations` (upstream #3288).

## Test plan
- [ ] `go build ./cmd/devicesimulator/... ./test/util/... ./test/harness/...`
- [ ] `make simulate-devices ARGS='--count=1 --log-level=info'`
- [ ] `make simulate-devices ARGS='--clean-only'`
- [ ] `make simulate-devices ARGS='--count=10 --fleet-count=2'`
- [ ] Rollout: `make simulate-devices ARGS='--rollout --fleet-count=2 --rollout-template=<fleet.yaml>'`


Made with [Cursor](https://cursor.com)