### PR TITLE
EDM-5028: Device/Fleet Mutate CAS and lifecycle prune

### DIFF
--- a/internal/domain/application_lifecycle.go
+++ b/internal/domain/application_lifecycle.go
@@ -125,6 +125,76 @@ func MergeApplicationLifecycleOverrides(raw string, overrides map[string]Applica
 	return string(encoded), nil
 }
 
+// PruneApplicationLifecycleOverrides drops override entries for apps no longer in apps.
+// deleteAnnotation is true when no overrides remain (caller should remove the annotation key).
+// changed is false when the annotation is already consistent with apps.
+func PruneApplicationLifecycleOverrides(raw string, apps *[]ApplicationProviderSpec) (encoded string, deleteAnnotation bool, changed bool, err error) {
+	overrides, err := decodeApplicationLifecycleOverrides(raw)
+	if err != nil {
+		return "", false, false, err
+	}
+	if len(overrides) == 0 {
+		return "", raw != "", raw != "", nil
+	}
+
+	kept := make(map[string]ApplicationLifecycleOverride, len(overrides))
+	for name, override := range overrides {
+		if ApplicationsContainName(apps, name) {
+			kept[name] = override
+		}
+	}
+	if len(kept) == len(overrides) {
+		return raw, false, false, nil
+	}
+	if len(kept) == 0 {
+		return "", true, true, nil
+	}
+	encodedBytes, err := json.Marshal(kept)
+	if err != nil {
+		return "", false, false, fmt.Errorf("failed to marshal application lifecycle annotation: %w", err)
+	}
+	return string(encodedBytes), false, true, nil
+}
+
+// PruneApplicationLifecycleAnnotationMap prunes the given lifecycle annotation keys against apps.
+// When changed is false, annotations is returned unchanged (same map reference).
+// When changed is true, a new map is returned with stale keys removed or rewritten.
+func PruneApplicationLifecycleAnnotationMap(annotations map[string]string, apps *[]ApplicationProviderSpec, keys ...string) (map[string]string, bool, error) {
+	if len(annotations) == 0 || len(keys) == 0 {
+		return annotations, false, nil
+	}
+	next := annotations
+	copied := false
+	changed := false
+	for _, key := range keys {
+		raw, ok := next[key]
+		if !ok {
+			continue
+		}
+		encoded, deleteAnnotation, didChange, err := PruneApplicationLifecycleOverrides(raw, apps)
+		if err != nil {
+			return nil, false, err
+		}
+		if !didChange {
+			continue
+		}
+		if !copied {
+			next = make(map[string]string, len(annotations))
+			for k, v := range annotations {
+				next[k] = v
+			}
+			copied = true
+		}
+		changed = true
+		if deleteAnnotation {
+			delete(next, key)
+			continue
+		}
+		next[key] = encoded
+	}
+	return next, changed, nil
+}
+
 func ApplicationsContainName(apps *[]ApplicationProviderSpec, appName string) bool {
 	if apps == nil {
 		return false

--- a/internal/domain/application_lifecycle_test.go
+++ b/internal/domain/application_lifecycle_test.go
@@ -268,3 +268,77 @@ func TestApplicationsContainName(t *testing.T) {
 		assert.False(t, ApplicationsContainName(&apps, "app-2"))
 	})
 }
+
+func TestPruneApplicationLifecycleAnnotationMap(t *testing.T) {
+	t.Run("When a lifecycle key is stale it should delete that key and leave others", func(t *testing.T) {
+		annotations := map[string]string{
+			DeviceAnnotationApplicationLifecycle: `{"app-1":{"desiredState":"stopped"}}`,
+			"other":                              "keep",
+		}
+		pruned, changed, err := PruneApplicationLifecycleAnnotationMap(
+			annotations, &[]ApplicationProviderSpec{}, DeviceAnnotationApplicationLifecycle)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Equal(t, map[string]string{"other": "keep"}, pruned)
+		assert.Contains(t, annotations, DeviceAnnotationApplicationLifecycle, "input map must not be mutated when unchanged keys remain")
+	})
+
+	t.Run("When nothing is stale it should return the same map", func(t *testing.T) {
+		apps := []ApplicationProviderSpec{newTestApp(t, "app-1")}
+		annotations := map[string]string{
+			DeviceAnnotationApplicationLifecycle: `{"app-1":{"desiredState":"stopped"}}`,
+		}
+		pruned, changed, err := PruneApplicationLifecycleAnnotationMap(
+			annotations, &apps, DeviceAnnotationApplicationLifecycle)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Equal(t, annotations, pruned)
+	})
+}
+
+func TestPruneApplicationLifecycleOverrides(t *testing.T) {
+	t.Run("When apps still contain the overridden name it should leave the annotation unchanged", func(t *testing.T) {
+		apps := []ApplicationProviderSpec{newTestApp(t, "app-1")}
+		raw := `{"app-1":{"desiredState":"stopped","desiredStateVersion":1}}`
+		encoded, deleteAnnotation, changed, err := PruneApplicationLifecycleOverrides(raw, &apps)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.False(t, deleteAnnotation)
+		assert.Equal(t, raw, encoded)
+	})
+
+	t.Run("When the overridden app is removed it should delete the annotation", func(t *testing.T) {
+		apps := []ApplicationProviderSpec{}
+		encoded, deleteAnnotation, changed, err := PruneApplicationLifecycleOverrides(
+			`{"app-1":{"desiredState":"stopped","desiredStateVersion":1}}`, &apps)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.True(t, deleteAnnotation)
+		assert.Empty(t, encoded)
+	})
+
+	t.Run("When one of two overridden apps is removed it should keep the remaining entry", func(t *testing.T) {
+		apps := []ApplicationProviderSpec{newTestApp(t, "app-2")}
+		encoded, deleteAnnotation, changed, err := PruneApplicationLifecycleOverrides(
+			`{"app-1":{"desiredState":"stopped"},"app-2":{"restartGeneration":3}}`, &apps)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.False(t, deleteAnnotation)
+		assert.JSONEq(t, `{"app-2":{"restartGeneration":3}}`, encoded)
+	})
+
+	t.Run("When the annotation is empty it should report no change", func(t *testing.T) {
+		apps := []ApplicationProviderSpec{newTestApp(t, "app-1")}
+		encoded, deleteAnnotation, changed, err := PruneApplicationLifecycleOverrides("", &apps)
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.False(t, deleteAnnotation)
+		assert.Empty(t, encoded)
+	})
+
+	t.Run("When the annotation is invalid JSON it should return an error", func(t *testing.T) {
+		apps := []ApplicationProviderSpec{newTestApp(t, "app-1")}
+		_, _, _, err := PruneApplicationLifecycleOverrides("not-json", &apps)
+		assert.Error(t, err)
+	})
+}

--- a/internal/instrumentation/metrics/domain/device_test.go
+++ b/internal/instrumentation/metrics/domain/device_test.go
@@ -48,6 +48,9 @@ func (m *MockDevice) Create(ctx context.Context, orgId uuid.UUID, device *domain
 func (m *MockDevice) Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, callback store.EventCallback) (*domain.Device, error) {
 	return nil, nil
 }
+func (m *MockDevice) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc, callback store.EventCallback) (*domain.Device, error) {
+	return nil, nil
+}
 func (m *MockDevice) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, callback store.EventCallback) (*domain.Device, bool, error) {
 	return nil, false, nil
 }

--- a/internal/instrumentation/metrics/domain/fleet_test.go
+++ b/internal/instrumentation/metrics/domain/fleet_test.go
@@ -39,6 +39,10 @@ func (m *MockFleetStore) Update(ctx context.Context, orgId uuid.UUID, fleet *dom
 	return nil, nil
 }
 
+func (m *MockFleetStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Fleet, apply fleetstore.FleetApplyFunc, callback store.EventCallback) (*domain.Fleet, error) {
+	return nil, nil
+}
+
 func (m *MockFleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, callback store.EventCallback) (*domain.Fleet, bool, error) {
 	return nil, false, nil
 }

--- a/internal/service/catalog/handler_test.go
+++ b/internal/service/catalog/handler_test.go
@@ -79,6 +79,9 @@ func (f *fakeDeviceStore) Create(context.Context, uuid.UUID, *domain.Device, sto
 func (f *fakeDeviceStore) Update(context.Context, uuid.UUID, *domain.Device, []string, devicestore.DeviceStoreValidationCallback, store.EventCallback) (*domain.Device, error) {
 	panic("not implemented")
 }
+func (f *fakeDeviceStore) Mutate(context.Context, uuid.UUID, string, *domain.Device, devicestore.DeviceApplyFunc, store.EventCallback) (*domain.Device, error) {
+	panic("not implemented")
+}
 func (f *fakeDeviceStore) CreateOrUpdate(context.Context, uuid.UUID, *domain.Device, []string, devicestore.DeviceStoreValidationCallback, store.EventCallback) (*domain.Device, bool, error) {
 	panic("not implemented")
 }
@@ -228,6 +231,9 @@ func (f *fakeFleetStore) Create(context.Context, uuid.UUID, *domain.Fleet, store
 	panic("not implemented")
 }
 func (f *fakeFleetStore) Update(context.Context, uuid.UUID, *domain.Fleet, []string, store.EventCallback) (*domain.Fleet, error) {
+	panic("not implemented")
+}
+func (f *fakeFleetStore) Mutate(context.Context, uuid.UUID, string, *domain.Fleet, fleetstore.FleetApplyFunc, store.EventCallback) (*domain.Fleet, error) {
 	panic("not implemented")
 }
 func (f *fakeFleetStore) CreateOrUpdate(context.Context, uuid.UUID, *domain.Fleet, []string, store.EventCallback) (*domain.Fleet, bool, error) {

--- a/internal/service/device/application_lifecycle.go
+++ b/internal/service/device/application_lifecycle.go
@@ -11,6 +11,35 @@ import (
 	"github.com/samber/lo"
 )
 
+// pruneLifecycleOnCurrent drops lifecycle overrides for apps no longer in Spec.Applications.
+func pruneLifecycleOnCurrent(device *domain.Device) error {
+	if device == nil {
+		return nil
+	}
+	var apps *[]domain.ApplicationProviderSpec
+	if device.Spec != nil {
+		apps = device.Spec.Applications
+	}
+	pruned, changed, err := domain.PruneApplicationLifecycleAnnotationMap(
+		lo.FromPtr(device.Metadata.Annotations),
+		apps,
+		domain.DeviceAnnotationApplicationLifecycle,
+		domain.DeviceAnnotationFleetApplicationLifecycle,
+	)
+	if err != nil || !changed {
+		return err
+	}
+	device.Metadata.Annotations = &pruned
+	return nil
+}
+
+func rejectDecommissionedDevice(current *domain.Device) error {
+	if current != nil && current.Spec != nil && current.Spec.Decommissioning != nil {
+		return flterrors.ErrDecommission
+	}
+	return nil
+}
+
 // StopDeviceApplication sets a device-level override so that the named application's
 // desiredState is "stopped", independent of the application's declarative spec. The override
 // is stamped with a fresh version so it wins over an earlier fleet-level default for the same

--- a/internal/service/device/application_lifecycle_test.go
+++ b/internal/service/device/application_lifecycle_test.go
@@ -185,3 +185,51 @@ func TestStopStartRestartDeviceApplication(t *testing.T) {
 		require.Equal(domain.EventReasonApplicationLifecycleChanged, ev.created[0].Reason)
 	})
 }
+
+func TestReplaceDevicePrunesStaleApplicationLifecycleOverride(t *testing.T) {
+	ctx := context.Background()
+	require := require.New(t)
+	h, _, _, orgId, deviceName := newLifecycleTestDevice(t, "app-1")
+
+	_, status := h.StopDeviceApplication(ctx, orgId, deviceName, "app-1")
+	require.Equal(int32(http.StatusOK), status.Code)
+
+	// Remove the app from the device spec while leaving annotations nil so the store
+	// preserves the existing lifecycle annotation (the bug path).
+	withoutApp := domain.Device{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+		Spec:     &domain.DeviceSpec{},
+	}
+	dev, status := h.ReplaceDevice(ctx, orgId, deviceName, withoutApp, nil, false, false)
+	require.Equal(int32(http.StatusOK), status.Code)
+	_, hasLifecycle := lo.FromPtr(dev.Metadata.Annotations)[domain.DeviceAnnotationApplicationLifecycle]
+	require.False(hasLifecycle, "lifecycle override for removed app must be pruned")
+
+	// Re-add the same app name/config; render overlay must not apply desiredState=stopped.
+	containerApp := domain.ContainerApplication{
+		AppType: domain.AppTypeContainer,
+		Name:    lo.ToPtr("app-1"),
+	}
+	require.NoError(containerApp.FromImageApplicationProviderSpec(domain.ImageApplicationProviderSpec{Image: "quay.io/test/app:v1"}))
+	var app domain.ApplicationProviderSpec
+	require.NoError(app.FromContainerApplication(containerApp))
+	withApp := domain.Device{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+		Spec: &domain.DeviceSpec{
+			Applications: &[]domain.ApplicationProviderSpec{app},
+		},
+	}
+	dev, status = h.ReplaceDevice(ctx, orgId, deviceName, withApp, nil, false, false)
+	require.Equal(int32(http.StatusOK), status.Code)
+	annotations := lo.FromPtr(dev.Metadata.Annotations)
+	_, hasLifecycle = annotations[domain.DeviceAnnotationApplicationLifecycle]
+	require.False(hasLifecycle)
+
+	apps := *dev.Spec.Applications
+	require.NoError(domain.OverlayApplicationLifecycle(
+		&apps,
+		annotations[domain.DeviceAnnotationApplicationLifecycle],
+		annotations[domain.DeviceAnnotationFleetApplicationLifecycle],
+	))
+	require.Equal(domain.ApplicationDesiredStateRunning, apps[0].GetDesiredState())
+}

--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -248,23 +248,51 @@ func (h *DeviceServiceHandler) ReplaceDevice(ctx context.Context, orgId uuid.UUI
 		return nil, status
 	}
 
-	if enforceOwnership || enforceCapabilities {
-		existing, getErr := h.deviceStore.Get(ctx, orgId, name)
-		if getErr != nil && !errors.Is(getErr, flterrors.ErrResourceNotFound) {
-			return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
-		}
-		if existing != nil && enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 && !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
-			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
-		}
-		if existing != nil && enforceCapabilities && isPackageModeOsImageConflict(existing, &device) {
-			return nil, domain.StatusBadRequest(flterrors.ErrOsImageNotSupportedOnPackageMode.Error())
-		}
+	existing, getErr := h.deviceStore.Get(ctx, orgId, name)
+	if getErr != nil && !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+		return nil, common.StoreErrorToApiStatus(getErr, false, domain.DeviceKind, &name)
+	}
+	if existing != nil && enforceOwnership && len(lo.FromPtr(existing.Metadata.Owner)) != 0 && !domain.DeviceSpecsAreEqual(lo.FromPtr(existing.Spec), lo.FromPtr(device.Spec)) {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.DeviceKind, &name)
+	}
+	if existing != nil && enforceCapabilities && isPackageModeOsImageConflict(existing, &device) {
+		return nil, domain.StatusBadRequest(flterrors.ErrOsImageNotSupportedOnPackageMode.Error())
 	}
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
-	result, created, err := h.deviceStore.CreateOrUpdate(ctx, orgId, &device, fieldsToUnset, DeviceVerificationCallback, h.callbackDeviceUpdated)
-	return result, common.StoreErrorToApiStatus(err, created, domain.DeviceKind, &name)
+	if existing == nil {
+		result, err := h.deviceStore.Create(ctx, orgId, &device, h.callbackDeviceUpdated)
+		return result, common.StoreErrorToApiStatus(err, true, domain.DeviceKind, &name)
+	}
+
+	result, err := h.deviceStore.Mutate(ctx, orgId, name, existing, func(current *domain.Device) error {
+		if err := rejectDecommissionedDevice(current); err != nil {
+			return err
+		}
+		if enforceOwnership && len(lo.FromPtr(current.Metadata.Owner)) != 0 && !domain.DeviceSpecsAreEqual(lo.FromPtr(current.Spec), lo.FromPtr(device.Spec)) {
+			return flterrors.ErrUpdatingResourceWithOwnerNotAllowed
+		}
+		if enforceCapabilities && isPackageModeOsImageConflict(current, &device) {
+			return flterrors.ErrOsImageNotSupportedOnPackageMode
+		}
+		// Copy request onto current (nil metadata on request preserves current via fieldsToUnset semantics).
+		if device.Spec != nil {
+			current.Spec = device.Spec
+		}
+		if device.Metadata.Labels != nil || lo.Contains(fieldsToUnset, "labels") {
+			current.Metadata.Labels = device.Metadata.Labels
+		}
+		if device.Metadata.Annotations != nil || lo.Contains(fieldsToUnset, "annotations") {
+			current.Metadata.Annotations = device.Metadata.Annotations
+		}
+		if device.Metadata.Owner != nil || lo.Contains(fieldsToUnset, "owner") {
+			current.Metadata.Owner = device.Metadata.Owner
+		}
+		_ = common.UpdateServiceSideStatus(ctx, orgId, current, h.fleetStore, h.log)
+		return pruneLifecycleOnCurrent(current)
+	}, h.callbackDeviceUpdated)
+	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
 func (h *DeviceServiceHandler) UpdateDevice(ctx context.Context, orgId uuid.UUID, name string, device domain.Device, fieldsToUnset []string) (*domain.Device, error) {
@@ -283,7 +311,25 @@ func (h *DeviceServiceHandler) UpdateDevice(ctx context.Context, orgId uuid.UUID
 	_ = common.UpdateServiceSideStatus(ctx, orgId, &device, h.fleetStore, h.log)
 
 	// Ownership is never enforced on UpdateDevice (agent/console trusted path).
-	return h.deviceStore.Update(ctx, orgId, &device, fieldsToUnset, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	return h.deviceStore.Mutate(ctx, orgId, name, nil, func(current *domain.Device) error {
+		if err := rejectDecommissionedDevice(current); err != nil {
+			return err
+		}
+		if device.Spec != nil {
+			current.Spec = device.Spec
+		}
+		if device.Metadata.Labels != nil || lo.Contains(fieldsToUnset, "labels") {
+			current.Metadata.Labels = device.Metadata.Labels
+		}
+		if device.Metadata.Annotations != nil || lo.Contains(fieldsToUnset, "annotations") {
+			current.Metadata.Annotations = device.Metadata.Annotations
+		}
+		if device.Metadata.Owner != nil || lo.Contains(fieldsToUnset, "owner") {
+			current.Metadata.Owner = device.Metadata.Owner
+		}
+		_ = common.UpdateServiceSideStatus(ctx, orgId, current, h.fleetStore, h.log)
+		return pruneLifecycleOnCurrent(current)
+	}, h.callbackDeviceUpdated)
 }
 
 func (h *DeviceServiceHandler) DeleteDevice(ctx context.Context, orgId uuid.UUID, name string) domain.Status {
@@ -506,7 +552,19 @@ func (h *DeviceServiceHandler) PatchDevice(ctx context.Context, orgId uuid.UUID,
 
 	_ = common.UpdateServiceSideStatus(ctx, orgId, newObj, h.fleetStore, h.log)
 
-	result, err := h.deviceStore.Update(ctx, orgId, newObj, nil, DeviceVerificationCallback, h.callbackDeviceUpdated)
+	result, err := h.deviceStore.Mutate(ctx, orgId, name, currentObj, func(current *domain.Device) error {
+		if err := rejectDecommissionedDevice(current); err != nil {
+			return err
+		}
+		// Annotations/owner were nil'd as managed fields; keep current's then prune lifecycle.
+		current.Spec = newObj.Spec
+		current.Metadata.Labels = newObj.Metadata.Labels
+		if newObj.Status != nil {
+			current.Status = newObj.Status
+		}
+		_ = common.UpdateServiceSideStatus(ctx, orgId, current, h.fleetStore, h.log)
+		return pruneLifecycleOnCurrent(current)
+	}, h.callbackDeviceUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 

--- a/internal/service/device/teststore_test.go
+++ b/internal/service/device/teststore_test.go
@@ -122,6 +122,25 @@ func (s *fakeDeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, d
 	return deepCopyDevice(d), created, nil
 }
 
+func (s *fakeDeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply devicestore.DeviceApplyFunc, eventCallback store.EventCallback) (*domain.Device, error) {
+	old, ok := s.devices[name]
+	if !ok {
+		return nil, flterrors.ErrResourceNotFound
+	}
+	current := deepCopyDevice(old)
+	if apply != nil {
+		if err := apply(current); err != nil {
+			return nil, err
+		}
+	}
+	d := deepCopyDevice(current)
+	s.devices[name] = d
+	if eventCallback != nil {
+		eventCallback(ctx, domain.DeviceKind, orgId, name, old, d, false, nil)
+	}
+	return deepCopyDevice(d), nil
+}
+
 func (s *fakeDeviceStore) Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback devicestore.DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error) {
 	name := lo.FromPtr(device.Metadata.Name)
 	old, ok := s.devices[name]

--- a/internal/service/fleet/application_lifecycle.go
+++ b/internal/service/fleet/application_lifecycle.go
@@ -7,7 +7,25 @@ import (
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/service/common"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 )
+
+// pruneFleetLifecycleOnCurrent drops fleet lifecycle defaults for apps no longer in the template.
+func pruneFleetLifecycleOnCurrent(fleet *domain.Fleet) error {
+	if fleet == nil {
+		return nil
+	}
+	pruned, changed, err := domain.PruneApplicationLifecycleAnnotationMap(
+		lo.FromPtr(fleet.Metadata.Annotations),
+		fleet.Spec.Template.Spec.Applications,
+		domain.FleetAnnotationApplicationLifecycle,
+	)
+	if err != nil || !changed {
+		return err
+	}
+	fleet.Metadata.Annotations = &pruned
+	return nil
+}
 
 // StopFleetApplication sets a fleet-level default so that the named application's desiredState
 // is "stopped" on every device currently owned by this fleet, independent of the application's

--- a/internal/service/fleet/application_lifecycle_test.go
+++ b/internal/service/fleet/application_lifecycle_test.go
@@ -135,3 +135,42 @@ func TestStopStartFleetApplication(t *testing.T) {
 		require.Equal(fleetName, ev.created[0].InvolvedObject.Name)
 	})
 }
+
+func TestReplaceFleetPrunesStaleApplicationLifecycleOverride(t *testing.T) {
+	ctx := context.Background()
+	require := require.New(t)
+	h, _, _, orgId, fleetName := newLifecycleTestFleet(t, "app-1")
+
+	_, status := h.StopFleetApplication(ctx, orgId, fleetName, "app-1")
+	require.Equal(int32(http.StatusOK), status.Code)
+
+	withoutApp := domain.Fleet{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr(fleetName)},
+	}
+	fleet, status := h.ReplaceFleet(ctx, orgId, fleetName, withoutApp, false)
+	require.Equal(int32(http.StatusOK), status.Code)
+	_, hasLifecycle := lo.FromPtr(fleet.Metadata.Annotations)[domain.FleetAnnotationApplicationLifecycle]
+	require.False(hasLifecycle, "lifecycle default for removed template app must be pruned")
+
+	containerApp := domain.ContainerApplication{
+		AppType: domain.AppTypeContainer,
+		Name:    lo.ToPtr("app-1"),
+	}
+	require.NoError(containerApp.FromImageApplicationProviderSpec(domain.ImageApplicationProviderSpec{Image: "quay.io/test/app:v1"}))
+	var app domain.ApplicationProviderSpec
+	require.NoError(app.FromContainerApplication(containerApp))
+	withApp := domain.Fleet{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr(fleetName)},
+	}
+	withApp.Spec.Template.Spec.Applications = &[]domain.ApplicationProviderSpec{app}
+
+	fleet, status = h.ReplaceFleet(ctx, orgId, fleetName, withApp, false)
+	require.Equal(int32(http.StatusOK), status.Code)
+	annotations := lo.FromPtr(fleet.Metadata.Annotations)
+	_, hasLifecycle = annotations[domain.FleetAnnotationApplicationLifecycle]
+	require.False(hasLifecycle)
+
+	apps := *fleet.Spec.Template.Spec.Applications
+	require.NoError(domain.OverlayApplicationLifecycle(&apps, "", annotations[domain.FleetAnnotationApplicationLifecycle]))
+	require.Equal(domain.ApplicationDesiredStateRunning, apps[0].GetDesiredState())
+}

--- a/internal/service/fleet/handler.go
+++ b/internal/service/fleet/handler.go
@@ -109,19 +109,36 @@ func (h *ServiceHandler) ReplaceFleet(ctx context.Context, orgId uuid.UUID, name
 		return nil, status
 	}
 
-	if enforceOwnership {
-		existing, getErr := h.store.Get(ctx, orgId, name)
-		if getErr != nil {
-			if !errors.Is(getErr, flterrors.ErrResourceNotFound) {
-				return nil, common.StoreErrorToApiStatus(getErr, false, domain.FleetKind, &name)
-			}
-		} else if fleetOwnershipConflict(existing, &fleet) {
-			return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
-		}
+	existing, getErr := h.store.Get(ctx, orgId, name)
+	if getErr != nil && !errors.Is(getErr, flterrors.ErrResourceNotFound) {
+		return nil, common.StoreErrorToApiStatus(getErr, false, domain.FleetKind, &name)
+	}
+	if existing != nil && enforceOwnership && fleetOwnershipConflict(existing, &fleet) {
+		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
 	}
 
-	result, created, err := h.store.CreateOrUpdate(ctx, orgId, &fleet, nil, h.callbackFleetUpdated)
-	return result, common.StoreErrorToApiStatus(err, created, domain.FleetKind, &name)
+	if existing == nil {
+		result, err := h.store.Create(ctx, orgId, &fleet, h.callbackFleetUpdated)
+		return result, common.StoreErrorToApiStatus(err, true, domain.FleetKind, &name)
+	}
+
+	result, err := h.store.Mutate(ctx, orgId, name, existing, func(current *domain.Fleet) error {
+		if enforceOwnership && fleetOwnershipConflict(current, &fleet) {
+			return flterrors.ErrUpdatingResourceWithOwnerNotAllowed
+		}
+		current.Spec = fleet.Spec
+		if fleet.Metadata.Labels != nil {
+			current.Metadata.Labels = fleet.Metadata.Labels
+		}
+		if fleet.Metadata.Annotations != nil {
+			current.Metadata.Annotations = fleet.Metadata.Annotations
+		}
+		if fleet.Metadata.Owner != nil {
+			current.Metadata.Owner = fleet.Metadata.Owner
+		}
+		return pruneFleetLifecycleOnCurrent(current)
+	}, h.callbackFleetUpdated)
+	return result, common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
 }
 
 // fleetOwnershipConflict reports whether replacing/patching an owned fleet's spec or
@@ -195,7 +212,12 @@ func (h *ServiceHandler) PatchFleet(ctx context.Context, orgId uuid.UUID, name s
 		return nil, common.StoreErrorToApiStatus(flterrors.ErrUpdatingResourceWithOwnerNotAllowed, false, domain.FleetKind, &name)
 	}
 
-	result, err := h.store.Update(ctx, orgId, newObj, nil, h.callbackFleetUpdated)
+	result, err := h.store.Mutate(ctx, orgId, name, currentObj, func(current *domain.Fleet) error {
+		// Annotations/owner were nil'd as managed fields; keep current's then prune lifecycle.
+		current.Spec = newObj.Spec
+		current.Metadata.Labels = newObj.Metadata.Labels
+		return pruneFleetLifecycleOnCurrent(current)
+	}, h.callbackFleetUpdated)
 	return result, common.StoreErrorToApiStatus(err, false, domain.FleetKind, &name)
 }
 

--- a/internal/service/fleet/handler_test.go
+++ b/internal/service/fleet/handler_test.go
@@ -2,7 +2,9 @@ package fleet
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -18,6 +20,21 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
+
+func deepCopyFleet(src *domain.Fleet) *domain.Fleet {
+	if src == nil {
+		return nil
+	}
+	b, err := json.Marshal(src)
+	if err != nil {
+		panic(fmt.Sprintf("deepCopyFleet failed in test: %v", err))
+	}
+	var dst domain.Fleet
+	if err := json.Unmarshal(b, &dst); err != nil {
+		panic(fmt.Sprintf("deepCopyFleet failed in test: %v", err))
+	}
+	return &dst
+}
 
 const (
 	statusSuccessCode     = int32(200)
@@ -89,11 +106,35 @@ func (f *fakeFleetStore) Update(ctx context.Context, orgId uuid.UUID, fleet *dom
 	if fleet.Metadata.Owner == nil {
 		fleet.Metadata.Owner = old.Metadata.Owner
 	}
+	if fleet.Metadata.Annotations == nil {
+		fleet.Metadata.Annotations = old.Metadata.Annotations
+	}
 	f.fleets[name] = fleet
 	if eventCallback != nil {
 		eventCallback(ctx, domain.FleetKind, orgId, name, old, fleet, false, nil)
 	}
 	return fleet, nil
+}
+
+func (f *fakeFleetStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Fleet, apply fleetstore.FleetApplyFunc, eventCallback store.EventCallback) (*domain.Fleet, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	old, exists := f.fleets[name]
+	if !exists {
+		return nil, flterrors.ErrResourceNotFound
+	}
+	current := deepCopyFleet(old)
+	if apply != nil {
+		if err := apply(current); err != nil {
+			return nil, err
+		}
+	}
+	f.fleets[name] = current
+	if eventCallback != nil {
+		eventCallback(ctx, domain.FleetKind, orgId, name, old, current, false, nil)
+	}
+	return deepCopyFleet(current), nil
 }
 
 func (f *fakeFleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, bool, error) {

--- a/internal/store/device/mutate.go
+++ b/internal/store/device/mutate.go
@@ -1,0 +1,239 @@
+package device
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"gorm.io/gorm"
+)
+
+// DeviceApplyFunc mutates current in place. It runs on every CAS attempt against a
+// freshly resolved device (or a clone of previous on the first attempt).
+type DeviceApplyFunc func(current *domain.Device) error
+
+// deviceWriteExtras carries columns not represented on domain.Device (rendered blobs).
+type deviceWriteExtras struct {
+	renderedConfig       *string
+	renderedApplications *string
+	renderedOsImage      *string
+	setRenderTimestamp   bool
+	serviceConditions    *model.JSONField[model.ServiceConditions]
+	skipWrite            bool
+}
+
+type deviceApplyInternal func(current *domain.Device, extras *deviceWriteExtras) error
+
+// Mutate loads the named device (or uses previous on the first attempt), runs apply,
+// and persists under resource_version CAS. On conflict/deadlock it reloads via Get and
+// retries; previous is never reused after the first attempt.
+func (s *DeviceStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply DeviceApplyFunc, eventCallback store.EventCallback) (*domain.Device, error) {
+	return s.mutateInternal(ctx, orgId, name, previous, func(current *domain.Device, _ *deviceWriteExtras) error {
+		return apply(current)
+	}, eventCallback)
+}
+
+func (s *DeviceStore) mutateInternal(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply deviceApplyInternal, eventCallback store.EventCallback) (*domain.Device, error) {
+	var (
+		updated  *domain.Device
+		oldForCb *domain.Device
+		err      error
+	)
+	attempt := 0
+	retryErr := retryUpdate(func() (bool, error) {
+		var usePrevious *domain.Device
+		if attempt == 0 {
+			usePrevious = previous
+		}
+		attempt++
+		var retry bool
+		var before *domain.Device
+		retry, updated, before, err = s.mutateOnce(ctx, orgId, name, usePrevious, apply)
+		if before != nil {
+			oldForCb = before
+		}
+		return retry, err
+	})
+	s.callEventCallback(ctx, eventCallback, orgId, name, oldForCb, updated, false, retryErr)
+	return updated, retryErr
+}
+
+func (s *DeviceStore) mutateOnce(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply deviceApplyInternal) (retry bool, updated, before *domain.Device, err error) {
+	var existing model.Device
+	var current *domain.Device
+
+	if previous != nil {
+		current, err = cloneDevice(previous)
+		if err != nil {
+			return false, nil, nil, err
+		}
+		before, err = cloneDevice(previous)
+		if err != nil {
+			return false, nil, nil, err
+		}
+		fromPrev, convErr := model.NewDeviceFromApiResource(previous)
+		if convErr != nil {
+			return false, nil, nil, convErr
+		}
+		fromPrev.OrgID = orgId
+		existing = *fromPrev
+	} else {
+		existing = model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
+		result := s.getDB(ctx).Take(&existing)
+		if result.Error != nil {
+			return false, nil, nil, store.ErrorFromGormError(result.Error)
+		}
+		current, err = existing.ToApiResource()
+		if err != nil {
+			return false, nil, nil, err
+		}
+		before, err = cloneDevice(current)
+		if err != nil {
+			return false, nil, nil, err
+		}
+	}
+
+	extras := &deviceWriteExtras{}
+	if err := apply(current, extras); err != nil {
+		return false, nil, before, err
+	}
+	if extras.skipWrite {
+		return false, current, before, nil
+	}
+
+	retry, err = s.persistDeviceCAS(ctx, &existing, current, extras)
+	if err != nil {
+		return retry, nil, before, err
+	}
+	return false, current, before, nil
+}
+
+func (s *DeviceStore) persistDeviceCAS(ctx context.Context, existing *model.Device, current *domain.Device, extras *deviceWriteExtras) (bool, error) {
+	fromAPI, err := model.NewDeviceFromApiResource(current)
+	if err != nil {
+		return false, err
+	}
+	fromAPI.OrgID = existing.OrgID
+
+	sameSpec := true
+	if existing.Spec != nil && fromAPI.Spec != nil {
+		sameSpec = fromAPI.HasSameSpecAs(existing)
+	} else if (existing.Spec == nil) != (fromAPI.Spec == nil) {
+		sameSpec = false
+	}
+	generation := lo.FromPtr(existing.Generation)
+	if !sameSpec {
+		generation++
+	}
+
+	updates := map[string]interface{}{
+		"spec":             fromAPI.Spec,
+		"alias":            fromAPI.Alias,
+		"labels":           model.MakeJSONMap(fromAPI.Labels),
+		"annotations":      model.MakeJSONMap(fromAPI.Annotations),
+		"owner":            fromAPI.Owner,
+		"generation":       generation,
+		"status":           fromAPI.Status,
+		"resource_version": gorm.Expr("resource_version + 1"),
+	}
+	if extras.serviceConditions != nil {
+		updates["service_conditions"] = extras.serviceConditions
+	} else {
+		updates["service_conditions"] = fromAPI.ServiceConditions
+	}
+	if extras.renderedConfig != nil {
+		raw := json.RawMessage(*extras.renderedConfig)
+		updates["rendered_config"] = model.MakeJSONField(raw)
+	}
+	if extras.renderedApplications != nil {
+		apps := *extras.renderedApplications
+		if strings.TrimSpace(apps) == "" {
+			apps = "[]"
+		}
+		raw := json.RawMessage(apps)
+		updates["rendered_applications"] = model.MakeJSONField(raw)
+	}
+	if extras.renderedOsImage != nil {
+		updates["rendered_os"] = model.MakeJSONField(domain.DeviceOsSpec{Image: *extras.renderedOsImage})
+	}
+	if extras.setRenderTimestamp {
+		updates["render_timestamp"] = time.Now()
+	}
+
+	result := s.getDB(ctx).Model(existing).Where("resource_version = ?", lo.FromPtr(existing.ResourceVersion)).Updates(updates)
+	updateErr := store.ErrorFromGormError(result.Error)
+	if updateErr != nil {
+		return strings.Contains(updateErr.Error(), "deadlock"), updateErr
+	}
+	if result.RowsAffected == 0 {
+		return true, flterrors.ErrNoRowsUpdated
+	}
+
+	current.Metadata.Generation = lo.ToPtr(generation)
+	if existing.ResourceVersion != nil {
+		current.Metadata.ResourceVersion = lo.ToPtr(strconv.FormatInt(*existing.ResourceVersion+1, 10))
+	}
+	return false, nil
+}
+
+func cloneDevice(d *domain.Device) (*domain.Device, error) {
+	if d == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(d)
+	if err != nil {
+		return nil, err
+	}
+	var out domain.Device
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func parseDeviceResourceVersion(d *domain.Device) (*int64, error) {
+	if d == nil || d.Metadata.ResourceVersion == nil {
+		return lo.ToPtr(int64(0)), nil
+	}
+	i, err := strconv.ParseInt(*d.Metadata.ResourceVersion, 10, 64)
+	if err != nil {
+		return nil, flterrors.ErrIllegalResourceVersionFormat
+	}
+	return &i, nil
+}
+
+// applyDeviceResourceUpdate copies mutable fields from resource onto current, preserving
+// nil metadata (unless listed in fieldsToUnset) to match generic update semantics.
+func applyDeviceResourceUpdate(current, resource *domain.Device, fieldsToUnset []string) {
+	if resource.Spec != nil {
+		current.Spec = resource.Spec
+	}
+	if resource.Status != nil {
+		current.Status = resource.Status
+	}
+	unset := func(field string) bool { return lo.Contains(fieldsToUnset, field) }
+
+	if resource.Metadata.Labels != nil || unset("labels") {
+		current.Metadata.Labels = resource.Metadata.Labels
+	}
+	if resource.Metadata.Annotations != nil || unset("annotations") {
+		current.Metadata.Annotations = resource.Metadata.Annotations
+	}
+	if resource.Metadata.Owner != nil || unset("owner") {
+		current.Metadata.Owner = resource.Metadata.Owner
+	}
+	if resource.Metadata.Generation != nil {
+		current.Metadata.Generation = resource.Metadata.Generation
+	}
+	if resource.Metadata.ResourceVersion != nil {
+		current.Metadata.ResourceVersion = resource.Metadata.ResourceVersion
+	}
+}

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -58,6 +58,8 @@ type Store interface {
 	Create(ctx context.Context, orgId uuid.UUID, device *domain.Device, eventCallback store.EventCallback) (*domain.Device, error)
 	Update(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error)
 	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, device *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error)
+	// Mutate applies handler logic under resource_version CAS. previous skips the first Get.
+	Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Device, apply DeviceApplyFunc, eventCallback store.EventCallback) (*domain.Device, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, error)
 	List(ctx context.Context, orgId uuid.UUID, listParams DeviceListParams) (*domain.DeviceList, error)
 	Labels(ctx context.Context, orgId uuid.UUID, listParams store.ListParams) (domain.LabelList, error)
@@ -116,6 +118,8 @@ type ServiceConditionsCallback func(ctx context.Context, orgId uuid.UUID, device
 // next rendered-version annotations applied. It returns true when status should be
 // persisted in the same CAS UPDATE as the rendered fields. Invoked on every retry.
 type RenderedStatusMutator func(device *domain.Device) bool
+
+// DeviceApplyFunc is declared in mutate.go.
 
 // Make sure we conform to the Store interface
 var _ Store = (*DeviceStore)(nil)
@@ -440,10 +444,16 @@ func (s *DeviceStore) Create(ctx context.Context, orgId uuid.UUID, resource *dom
 }
 
 func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, error) {
-	device, oldDevice, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, validationCallback)
 	name := lo.FromPtr(resource.Metadata.Name)
-	s.callEventCallback(ctx, eventCallback, orgId, name, oldDevice, device, false, err)
-	return device, err
+	return s.Mutate(ctx, orgId, name, nil, func(current *domain.Device) error {
+		if validationCallback != nil {
+			if err := validationCallback(ctx, current, resource); err != nil {
+				return err
+			}
+		}
+		applyDeviceResourceUpdate(current, resource, fieldsToUnset)
+		return nil
+	}, eventCallback)
 }
 
 func (s *DeviceStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Device, fieldsToUnset []string, validationCallback DeviceStoreValidationCallback, eventCallback store.EventCallback) (*domain.Device, bool, error) {
@@ -883,93 +893,43 @@ func (s *DeviceStore) Summary(ctx context.Context, orgId uuid.UUID, listParams s
 }
 
 func (s *DeviceStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, resource *domain.Device, eventCallback store.EventCallback, previous *domain.Device) (*domain.Device, error) {
-	var oldDevice domain.Device
 	name := lo.FromPtr(resource.Metadata.Name)
-	if previous != nil {
-		oldDevice = *previous
-	} else {
-		device, err := s.Get(ctx, orgId, name)
-		if err != nil {
-			s.log.Errorf("error fetching device %s/%s for update status event processing", orgId, name)
-		} else if device != nil {
-			oldDevice = *device
-		}
-	}
-
-	device, err := s.genericStore.UpdateStatus(ctx, orgId, resource)
-	s.callEventCallback(ctx, eventCallback, orgId, name, &oldDevice, device, false, err)
-	return device, err
-}
-
-// updateAnnotationsCAS loads the device's current annotations, applies transform to compute the
-// new annotations map, and writes it back guarded by the resource_version optimistic-lock clause,
-// shared by updateAnnotations and mutateAnnotation so their read/update/retry semantics (deadlock
-// detection, ErrNoRowsUpdated on a lost race) can't drift between the two.
-func (s *DeviceStore) updateAnnotationsCAS(ctx context.Context, orgId uuid.UUID, name string, transform func(map[string]string) (map[string]string, error)) (bool, error) {
-	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, store.ErrorFromGormError(result.Error)
-	}
-	existingAnnotations := util.EnsureMap(existingRecord.Annotations)
-
-	newAnnotations, err := transform(existingAnnotations)
-	if err != nil {
-		return false, err
-	}
-
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-		"annotations":      model.MakeJSONMap(newAnnotations),
-		"resource_version": gorm.Expr("resource_version + 1"),
-	})
-
-	updateErr := store.ErrorFromGormError(result.Error)
-	if updateErr != nil {
-		return strings.Contains(updateErr.Error(), "deadlock"), updateErr
-	}
-	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
-	}
-	return false, nil
-}
-
-func (s *DeviceStore) updateAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) (bool, error) {
-	return s.updateAnnotationsCAS(ctx, orgId, name, func(existingAnnotations map[string]string) (map[string]string, error) {
-		existingAnnotations = util.MergeLabels(existingAnnotations, annotations)
-		for _, deleteKey := range deleteKeys {
-			delete(existingAnnotations, deleteKey)
-		}
-		return existingAnnotations, nil
-	})
+	return s.Mutate(ctx, orgId, name, previous, func(current *domain.Device) error {
+		current.Status = resource.Status
+		return nil
+	}, eventCallback)
 }
 
 func (s *DeviceStore) UpdateAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string) error {
-	return retryUpdate(func() (bool, error) {
-		return s.updateAnnotations(ctx, orgId, name, annotations, deleteKeys)
-	})
-}
-
-// mutateAnnotation freshly reads the device's current annotations on every attempt and calls
-// mutate with the current value of key (the empty string if unset), storing the returned value
-// back under that same key. Unlike updateAnnotations/UpdateAnnotations, which apply a value
-// computed once outside the retry loop, this re-invokes mutate against the freshly-read value
-// on every retry, making it safe for atomic read-modify-write updates (e.g. incrementing a
-// counter) under concurrent writers.
-func (s *DeviceStore) mutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) (bool, error) {
-	return s.updateAnnotationsCAS(ctx, orgId, name, func(existingAnnotations map[string]string) (map[string]string, error) {
-		newValue, err := mutate(existingAnnotations[key])
-		if err != nil {
-			return nil, err
+	_, err := s.Mutate(ctx, orgId, name, nil, func(current *domain.Device) error {
+		merged := util.MergeLabels(util.EnsureMap(lo.FromPtr(current.Metadata.Annotations)), annotations)
+		for _, deleteKey := range deleteKeys {
+			delete(merged, deleteKey)
 		}
-		existingAnnotations[key] = newValue
-		return existingAnnotations, nil
-	})
+		current.Metadata.Annotations = &merged
+		return nil
+	}, nil)
+	return err
 }
 
+// MutateAnnotation re-invokes mutate against the current key value on every CAS attempt.
+// An empty return value deletes the key.
 func (s *DeviceStore) MutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) error {
-	return retryUpdate(func() (bool, error) {
-		return s.mutateAnnotation(ctx, orgId, name, key, mutate)
-	})
+	_, err := s.Mutate(ctx, orgId, name, nil, func(current *domain.Device) error {
+		ann := util.EnsureMap(lo.FromPtr(current.Metadata.Annotations))
+		newValue, err := mutate(ann[key])
+		if err != nil {
+			return err
+		}
+		if newValue == "" {
+			delete(ann, key)
+		} else {
+			ann[key] = newValue
+		}
+		current.Metadata.Annotations = &ann
+		return nil
+	}, nil)
+	return err
 }
 
 func (s *DeviceStore) healthcheck(ctx context.Context, orgId uuid.UUID, names []string) (bool, error) {
@@ -1172,95 +1132,6 @@ func (s *DeviceStore) SetOutOfDate(ctx context.Context, orgId uuid.UUID, owner s
 	})
 }
 
-func (s *DeviceStore) updateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, mutateStatus RenderedStatusMutator) (retry bool, renderedVersion string, err error) {
-	existingRecord := model.Device{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, "", store.ErrorFromGormError(result.Error)
-	}
-	existingAnnotations := util.EnsureMap(existingRecord.Annotations)
-
-	var deviceStatus *domain.DeviceStatus
-	if existingRecord.Status != nil {
-		deviceStatus = &existingRecord.Status.Data
-	}
-
-	nextRenderedVersion, err := domain.GetNextDeviceRenderedVersion(existingAnnotations, deviceStatus)
-	if err != nil {
-		return false, "", err
-	}
-
-	hash := specHash
-
-	existingAnnotations[domain.DeviceAnnotationRenderedVersion] = nextRenderedVersion
-	if lo.HasKey(existingAnnotations, domain.DeviceAnnotationTemplateVersion) {
-		existingAnnotations[domain.DeviceAnnotationRenderedTemplateVersion] = existingAnnotations[domain.DeviceAnnotationTemplateVersion]
-	}
-
-	specUnchanged := false
-	if lo.HasKey(existingAnnotations, domain.DeviceAnnotationRenderedSpecHash) {
-		if existingAnnotations[domain.DeviceAnnotationRenderedSpecHash] == hash {
-			specUnchanged = true
-		}
-	}
-
-	// Build dependency sync status from fingerprints, preserving lastUpdatedAt for unchanged entries
-	updatedServiceConditions := buildDependencySyncStatus(existingRecord.ServiceConditions, configFingerprints)
-
-	// forceUpdate bypasses the specUnchanged short-circuit for callers that already determined
-	// (using fresher or additional context than specHash alone, e.g. a device-level application
-	// lifecycle annotation change) that this render must be persisted regardless of hash equality.
-	if specUnchanged && len(configFingerprints) == 0 && !forceUpdate {
-		return false, "", nil
-	}
-
-	existingAnnotations[domain.DeviceAnnotationRenderedSpecHash] = hash
-
-	renderedApplicationsJSON := renderedApplications
-	if strings.TrimSpace(renderedApplications) == "" {
-		renderedApplicationsJSON = "[]"
-	}
-
-	updates := map[string]interface{}{
-		"annotations":           model.MakeJSONMap(existingAnnotations),
-		"rendered_config":       &renderedConfig,
-		"rendered_applications": &renderedApplicationsJSON,
-		"resource_version":      gorm.Expr("resource_version + 1"),
-		"render_timestamp":      time.Now(),
-	}
-
-	updates["rendered_os"] = model.MakeJSONField(domain.DeviceOsSpec{Image: osImage})
-
-	if mutateStatus != nil {
-		existingRecord.Annotations = model.MakeJSONMap(existingAnnotations)
-		apiDevice, convertErr := existingRecord.ToApiResource()
-		if convertErr != nil {
-			return false, "", convertErr
-		}
-		if mutateStatus(apiDevice) && apiDevice.Status != nil {
-			deviceOnlyRecord, convertErr := model.NewDeviceFromApiResource(apiDevice)
-			if convertErr != nil {
-				return false, "", convertErr
-			}
-			updates["status"] = deviceOnlyRecord.Status
-		}
-	}
-
-	// SpecValid=Valid is part of a successful render write (same CAS UPDATE).
-	updates["service_conditions"] = withSpecValidCondition(updatedServiceConditions, existingRecord.ServiceConditions)
-
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(updates)
-
-	err = store.ErrorFromGormError(result.Error)
-	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), "", err
-	}
-	if result.RowsAffected == 0 {
-		return true, "", flterrors.ErrNoRowsUpdated
-	}
-	return false, nextRenderedVersion, nil
-}
-
 // withSpecValidCondition returns service conditions for a successful render write,
 // starting from fingerprint updates when present, otherwise the existing row, and
 // setting SpecValid=Valid in the same payload.
@@ -1330,17 +1201,54 @@ func buildDependencySyncStatus(existing *model.JSONField[model.ServiceConditions
 }
 
 func (s *DeviceStore) UpdateRendered(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, mutateStatus RenderedStatusMutator) (string, error) {
-	var rv string
+	var renderedVersion string
+	_, err := s.mutateInternal(ctx, orgId, name, nil, func(current *domain.Device, extras *deviceWriteExtras) error {
+		ann := util.EnsureMap(lo.FromPtr(current.Metadata.Annotations))
+		var deviceStatus *domain.DeviceStatus
+		if current.Status != nil {
+			deviceStatus = current.Status
+		}
+		next, err := domain.GetNextDeviceRenderedVersion(ann, deviceStatus)
+		if err != nil {
+			return err
+		}
+		ann[domain.DeviceAnnotationRenderedVersion] = next
+		if lo.HasKey(ann, domain.DeviceAnnotationTemplateVersion) {
+			ann[domain.DeviceAnnotationRenderedTemplateVersion] = ann[domain.DeviceAnnotationTemplateVersion]
+		}
+		specUnchanged := lo.HasKey(ann, domain.DeviceAnnotationRenderedSpecHash) &&
+			ann[domain.DeviceAnnotationRenderedSpecHash] == specHash
+		if specUnchanged && len(configFingerprints) == 0 && !forceUpdate {
+			extras.skipWrite = true
+			renderedVersion = ""
+			return nil
+		}
+		ann[domain.DeviceAnnotationRenderedSpecHash] = specHash
+		current.Metadata.Annotations = &ann
 
-	wrapper := func() (bool, error) {
-		var retry bool
-		var err error
-		retry, rv, err = s.updateRendered(ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate, mutateStatus)
-		return retry, err
-	}
+		asModel, convErr := model.NewDeviceFromApiResource(current)
+		if convErr != nil {
+			return convErr
+		}
+		updatedSC := buildDependencySyncStatus(asModel.ServiceConditions, configFingerprints)
+		extras.serviceConditions = withSpecValidCondition(updatedSC, asModel.ServiceConditions)
 
-	err := retryUpdate(wrapper)
-	return rv, err
+		if mutateStatus != nil {
+			statusBefore := current.Status
+			if !mutateStatus(current) {
+				current.Status = statusBefore
+			}
+		}
+
+		extras.renderedConfig = &renderedConfig
+		apps := renderedApplications
+		extras.renderedApplications = &apps
+		extras.renderedOsImage = &osImage
+		extras.setRenderTimestamp = true
+		renderedVersion = next
+		return nil
+	}, nil)
+	return renderedVersion, err
 }
 
 func (s *DeviceStore) GetRendered(ctx context.Context, orgId uuid.UUID, name string, knownRenderedVersion *string, consoleGrpcEndpoint string) (*domain.Device, error) {

--- a/internal/store/fleet/mutate.go
+++ b/internal/store/fleet/mutate.go
@@ -1,0 +1,181 @@
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"gorm.io/gorm"
+)
+
+// FleetApplyFunc mutates current in place. It runs on every CAS attempt.
+type FleetApplyFunc func(current *domain.Fleet) error
+
+// errMutateSkipWrite tells Mutate to return success without writing (e.g. conditions unchanged).
+var errMutateSkipWrite = errors.New("mutate skip write")
+
+// Mutate loads the named fleet (or uses previous on the first attempt), runs apply,
+// and persists under resource_version CAS.
+func (s *FleetStore) Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Fleet, apply FleetApplyFunc, eventCallback store.EventCallback) (*domain.Fleet, error) {
+	var (
+		updated  *domain.Fleet
+		oldForCb *domain.Fleet
+		err      error
+	)
+	attempt := 0
+	retryErr := retryUpdate(func() (bool, error) {
+		var usePrevious *domain.Fleet
+		if attempt == 0 {
+			usePrevious = previous
+		}
+		attempt++
+		var retry bool
+		var before *domain.Fleet
+		retry, updated, before, err = s.mutateOnce(ctx, orgId, name, usePrevious, apply)
+		if before != nil {
+			oldForCb = before
+		}
+		return retry, err
+	})
+	s.callEventCallback(ctx, eventCallback, orgId, name, oldForCb, updated, false, retryErr)
+	return updated, retryErr
+}
+
+func (s *FleetStore) mutateOnce(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Fleet, apply FleetApplyFunc) (retry bool, updated, before *domain.Fleet, err error) {
+	var existing model.Fleet
+	var current *domain.Fleet
+
+	if previous != nil {
+		current, err = cloneFleet(previous)
+		if err != nil {
+			return false, nil, nil, err
+		}
+		before, err = cloneFleet(previous)
+		if err != nil {
+			return false, nil, nil, err
+		}
+		fromPrev, convErr := model.NewFleetFromApiResource(previous)
+		if convErr != nil {
+			return false, nil, nil, convErr
+		}
+		fromPrev.OrgID = orgId
+		existing = *fromPrev
+	} else {
+		existing = model.Fleet{Resource: model.Resource{OrgID: orgId, Name: name}}
+		result := s.getDB(ctx).Take(&existing)
+		if result.Error != nil {
+			return false, nil, nil, store.ErrorFromGormError(result.Error)
+		}
+		current, err = existing.ToApiResource()
+		if err != nil {
+			return false, nil, nil, err
+		}
+		before, err = cloneFleet(current)
+		if err != nil {
+			return false, nil, nil, err
+		}
+	}
+
+	if err := apply(current); err != nil {
+		if errors.Is(err, errMutateSkipWrite) {
+			return false, current, before, nil
+		}
+		return false, nil, before, err
+	}
+
+	retry, err = s.persistFleetCAS(ctx, &existing, current)
+	if err != nil {
+		return retry, nil, before, err
+	}
+	return false, current, before, nil
+}
+
+func (s *FleetStore) persistFleetCAS(ctx context.Context, existing *model.Fleet, current *domain.Fleet) (bool, error) {
+	fromAPI, err := model.NewFleetFromApiResource(current)
+	if err != nil {
+		return false, err
+	}
+	fromAPI.OrgID = existing.OrgID
+
+	sameSpec := true
+	if existing.Spec != nil && fromAPI.Spec != nil {
+		sameSpec = fromAPI.HasSameSpecAs(existing)
+	} else if (existing.Spec == nil) != (fromAPI.Spec == nil) {
+		sameSpec = false
+	}
+	generation := lo.FromPtr(existing.Generation)
+	if !sameSpec {
+		generation++
+	}
+
+	updates := map[string]interface{}{
+		"spec":             fromAPI.Spec,
+		"labels":           model.MakeJSONMap(fromAPI.Labels),
+		"annotations":      model.MakeJSONMap(fromAPI.Annotations),
+		"owner":            fromAPI.Owner,
+		"generation":       generation,
+		"status":           fromAPI.Status,
+		"resource_version": gorm.Expr("resource_version + 1"),
+	}
+
+	result := s.getDB(ctx).Model(existing).Where("resource_version = ?", lo.FromPtr(existing.ResourceVersion)).Updates(updates)
+	updateErr := store.ErrorFromGormError(result.Error)
+	if updateErr != nil {
+		return strings.Contains(updateErr.Error(), "deadlock"), updateErr
+	}
+	if result.RowsAffected == 0 {
+		return true, flterrors.ErrNoRowsUpdated
+	}
+
+	current.Metadata.Generation = lo.ToPtr(generation)
+	if existing.ResourceVersion != nil {
+		current.Metadata.ResourceVersion = lo.ToPtr(strconv.FormatInt(*existing.ResourceVersion+1, 10))
+	}
+	return false, nil
+}
+
+func cloneFleet(f *domain.Fleet) (*domain.Fleet, error) {
+	if f == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(f)
+	if err != nil {
+		return nil, err
+	}
+	var out domain.Fleet
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func applyFleetResourceUpdate(current, resource *domain.Fleet, fieldsToUnset []string) {
+	current.Spec = resource.Spec
+	if resource.Status != nil {
+		current.Status = resource.Status
+	}
+	unset := func(field string) bool { return lo.Contains(fieldsToUnset, field) }
+	if resource.Metadata.Labels != nil || unset("labels") {
+		current.Metadata.Labels = resource.Metadata.Labels
+	}
+	if resource.Metadata.Annotations != nil || unset("annotations") {
+		current.Metadata.Annotations = resource.Metadata.Annotations
+	}
+	if resource.Metadata.Owner != nil || unset("owner") {
+		current.Metadata.Owner = resource.Metadata.Owner
+	}
+	if resource.Metadata.Generation != nil {
+		current.Metadata.Generation = resource.Metadata.Generation
+	}
+	if resource.Metadata.ResourceVersion != nil {
+		current.Metadata.ResourceVersion = resource.Metadata.ResourceVersion
+	}
+}

--- a/internal/store/fleet/store.go
+++ b/internal/store/fleet/store.go
@@ -5,7 +5,6 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
@@ -25,6 +24,8 @@ type Store interface {
 	Create(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, eventCallback store.EventCallback) (*domain.Fleet, error)
 	Update(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, error)
 	CreateOrUpdate(ctx context.Context, orgId uuid.UUID, fleet *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, bool, error)
+	// Mutate applies handler logic under resource_version CAS. previous skips the first Get.
+	Mutate(ctx context.Context, orgId uuid.UUID, name string, previous *domain.Fleet, apply FleetApplyFunc, eventCallback store.EventCallback) (*domain.Fleet, error)
 	Get(ctx context.Context, orgId uuid.UUID, name string, opts ...GetOption) (*domain.Fleet, error)
 	List(ctx context.Context, orgId uuid.UUID, listParams store.ListParams, opts ...ListOption) (*domain.FleetList, error)
 	Delete(ctx context.Context, orgId uuid.UUID, name string, eventCallback store.EventCallback) error
@@ -165,9 +166,11 @@ func (s *FleetStore) Create(ctx context.Context, orgId uuid.UUID, resource *doma
 }
 
 func (s *FleetStore) Update(ctx context.Context, orgId uuid.UUID, resource *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, error) {
-	newFleet, oldFleet, err := s.genericStore.Update(ctx, orgId, resource, fieldsToUnset, nil)
-	s.callEventCallback(ctx, eventCallback, orgId, lo.FromPtr(resource.Metadata.Name), oldFleet, newFleet, false, err)
-	return newFleet, err
+	name := lo.FromPtr(resource.Metadata.Name)
+	return s.Mutate(ctx, orgId, name, nil, func(current *domain.Fleet) error {
+		applyFleetResourceUpdate(current, resource, fieldsToUnset)
+		return nil
+	}, eventCallback)
 }
 
 func (s *FleetStore) CreateOrUpdate(ctx context.Context, orgId uuid.UUID, resource *domain.Fleet, fieldsToUnset []string, eventCallback store.EventCallback) (*domain.Fleet, bool, error) {
@@ -421,7 +424,11 @@ func (s *FleetStore) Delete(ctx context.Context, orgId uuid.UUID, name string, e
 	return err
 }
 func (s *FleetStore) UpdateStatus(ctx context.Context, orgId uuid.UUID, resource *domain.Fleet) (*domain.Fleet, error) {
-	return s.genericStore.UpdateStatus(ctx, orgId, resource)
+	name := lo.FromPtr(resource.Metadata.Name)
+	return s.Mutate(ctx, orgId, name, nil, func(current *domain.Fleet) error {
+		current.Status = resource.Status
+		return nil
+	}, nil)
 }
 
 func (s *FleetStore) UnsetOwner(ctx context.Context, tx *gorm.DB, orgId uuid.UUID, owner string) error {
@@ -454,126 +461,58 @@ func (s *FleetStore) UnsetOwnerByKind(ctx context.Context, tx *gorm.DB, orgId uu
 	return store.ErrorFromGormError(result.Error)
 }
 
-func (s *FleetStore) updateConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, eventCallback store.EventCallback) (bool, error) {
-	existingRecord := model.Fleet{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, store.ErrorFromGormError(result.Error)
-	}
-
-	if existingRecord.Status == nil {
-		existingRecord.Status = model.MakeJSONField(domain.FleetStatus{})
-	}
-	if existingRecord.Status.Data.Conditions == nil {
-		existingRecord.Status.Data.Conditions = []domain.Condition{}
-	}
-
-	// Make a full copy of the existing conditions
-	existingConditions := make([]domain.Condition, len(existingRecord.Status.Data.Conditions))
-	copy(existingConditions, existingRecord.Status.Data.Conditions)
-
-	changed := false
-	for _, condition := range conditions {
-		if domain.SetStatusCondition(&existingRecord.Status.Data.Conditions, condition) {
-			changed = true
-		}
-	}
-	if !changed {
-		return false, nil
-	}
-
-	result = s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-		"status":           existingRecord.Status,
-		"resource_version": gorm.Expr("resource_version + 1"),
-	})
-	err := store.ErrorFromGormError(result.Error)
-	if err != nil {
-		return strings.Contains(err.Error(), "deadlock"), err
-	}
-	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
-	}
-
-	oldFleet, _ := existingRecord.ToApiResource()
-	oldFleet.Status.Conditions = existingConditions
-	newFleet, _ := existingRecord.ToApiResource()
-	s.callEventCallback(ctx, eventCallback, orgId, name, oldFleet, newFleet, false, err)
-	return false, nil
-}
-
 func (s *FleetStore) UpdateConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition, eventCallback store.EventCallback) error {
-	return retryUpdate(func() (bool, error) {
-		return s.updateConditions(ctx, orgId, name, conditions, eventCallback)
-	})
-}
-
-func (s *FleetStore) updateAnnotations(ctx context.Context, existingRecord model.Fleet, existingAnnotations map[string]string) (bool, error) {
-	result := s.getDB(ctx).Model(existingRecord).Where("resource_version = ?", lo.FromPtr(existingRecord.ResourceVersion)).Updates(map[string]interface{}{
-		"annotations":      model.MakeJSONMap(existingAnnotations),
-		"resource_version": gorm.Expr("resource_version + 1"),
-	})
-	if err := store.ErrorFromGormError(result.Error); err != nil {
-		return strings.Contains(err.Error(), "deadlock"), err
-	}
-	if result.RowsAffected == 0 {
-		return true, flterrors.ErrNoRowsUpdated
-	}
-	return false, nil
-}
-
-func (s *FleetStore) UpdateAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string, eventCallback store.EventCallback) error {
-	existingRecord := model.Fleet{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return store.ErrorFromGormError(result.Error)
-	}
-
-	existingAnnotations := util.EnsureMap(existingRecord.Annotations)
-	newAnnotations := util.MergeLabels(existingAnnotations, annotations)
-	for _, deleteKey := range deleteKeys {
-		delete(newAnnotations, deleteKey)
-	}
-	err := retryUpdate(func() (bool, error) {
-		return s.updateAnnotations(ctx, existingRecord, newAnnotations)
-	})
-
-	oldFleet := &domain.Fleet{Metadata: domain.ObjectMeta{
-		Annotations: &existingAnnotations,
-	}}
-	newFleet := &domain.Fleet{Metadata: domain.ObjectMeta{
-		Annotations: &newAnnotations,
-	}}
-	s.callEventCallback(ctx, eventCallback, orgId, name, oldFleet, newFleet, false, err)
+	_, err := s.Mutate(ctx, orgId, name, nil, func(current *domain.Fleet) error {
+		if current.Status == nil {
+			current.Status = &domain.FleetStatus{}
+		}
+		if current.Status.Conditions == nil {
+			current.Status.Conditions = []domain.Condition{}
+		}
+		changed := false
+		for _, condition := range conditions {
+			if domain.SetStatusCondition(&current.Status.Conditions, condition) {
+				changed = true
+			}
+		}
+		if !changed {
+			return errMutateSkipWrite
+		}
+		return nil
+	}, eventCallback)
 	return err
 }
 
-// mutateAnnotation freshly reads the fleet's current annotations on every attempt and calls
-// mutate with the current value of key (the empty string if unset), storing the returned value
-// back under that same key. Mirrors DeviceStore.mutateAnnotation: re-invoking mutate against the
-// freshly-read value on every retry makes it safe for atomic read-modify-write updates under
-// concurrent writers, unlike UpdateAnnotations above which computes its value once outside the
-// retry loop.
-func (s *FleetStore) mutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) (bool, error) {
-	existingRecord := model.Fleet{Resource: model.Resource{OrgID: orgId, Name: name}}
-	result := s.getDB(ctx).Take(&existingRecord)
-	if result.Error != nil {
-		return false, store.ErrorFromGormError(result.Error)
-	}
-	existingAnnotations := util.EnsureMap(existingRecord.Annotations)
-
-	newValue, err := mutate(existingAnnotations[key])
-	if err != nil {
-		return false, err
-	}
-	existingAnnotations[key] = newValue
-
-	return s.updateAnnotations(ctx, existingRecord, existingAnnotations)
+func (s *FleetStore) UpdateAnnotations(ctx context.Context, orgId uuid.UUID, name string, annotations map[string]string, deleteKeys []string, eventCallback store.EventCallback) error {
+	_, err := s.Mutate(ctx, orgId, name, nil, func(current *domain.Fleet) error {
+		merged := util.MergeLabels(util.EnsureMap(lo.FromPtr(current.Metadata.Annotations)), annotations)
+		for _, deleteKey := range deleteKeys {
+			delete(merged, deleteKey)
+		}
+		current.Metadata.Annotations = &merged
+		return nil
+	}, eventCallback)
+	return err
 }
 
+// MutateAnnotation re-invokes mutate against the current key value on every CAS attempt.
+// An empty return value deletes the key.
 func (s *FleetStore) MutateAnnotation(ctx context.Context, orgId uuid.UUID, name string, key string, mutate func(current string) (string, error)) error {
-	return retryUpdate(func() (bool, error) {
-		return s.mutateAnnotation(ctx, orgId, name, key, mutate)
-	})
+	_, err := s.Mutate(ctx, orgId, name, nil, func(current *domain.Fleet) error {
+		ann := util.EnsureMap(lo.FromPtr(current.Metadata.Annotations))
+		newValue, err := mutate(ann[key])
+		if err != nil {
+			return err
+		}
+		if newValue == "" {
+			delete(ann, key)
+		} else {
+			ann[key] = newValue
+		}
+		current.Metadata.Annotations = &ann
+		return nil
+	}, nil)
+	return err
 }
 
 func (s *FleetStore) OverwriteRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) error {


### PR DESCRIPTION
## Summary
- Add store-native `DeviceStore.Mutate` / `FleetStore.Mutate` with optional `previous`, always-CAS `resource_version` writes, and retry that always re-Gets after conflict/deadlock.
- Migrate single-resource writers (`Update`, `UpdateStatus`, annotations, `UpdateRendered` / `UpdateConditions`) onto Mutate wrappers; keep bulk/side-table APIs separate.
- Re-land EDM-5028: prune stale application lifecycle overrides inside device/fleet Replace/Update/Patch `apply` closures (depends on #3351).

## Test plan
- [x] `go test ./internal/service/device/ ./internal/service/fleet/ ./internal/service/catalog/ ./internal/instrumentation/metrics/domain/ ./internal/domain/ ./internal/store/device/ ./internal/store/fleet/`
- [ ] Confirm recreate-app lifecycle tests (`TestReplaceDevicePrunesStaleApplicationLifecycleOverride`, `TestReplaceFleetPrunesStaleApplicationLifecycleOverride`)
- [ ] Smoke replace/patch device and fleet with leftover lifecycle annotation after app removal

Fixes EDM-5028

Depends on https://github.com/flightctl/flightctl/pull/3351


Made with [Cursor](https://cursor.com)